### PR TITLE
auth0によるパスワードの変更とプロフィール設定画面のレイアウトを実装

### DIFF
--- a/.github/workflows/mbg.yml
+++ b/.github/workflows/mbg.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
         ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} 'cd MangaBestGram-app &&
-        git pull origin 11_overall-adjustment:main &&
+        git pull origin 12_change-information-auth0:main &&
         docker-compose down --rmi all &&
         docker rmi $(docker images -q)
         cd frontend &&

--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -11,9 +11,10 @@ import { BsBookFill, BsJournalBookmarkFill, BsChevronDoubleDown } from "react-ic
 
 const Home = () => {
   const { useGetGeneralLatestComic } = useGeneralComic();
-  const { data: comics, isLoading } = useGetGeneralLatestComic();
-  const { isAuthenticated, loginWithRedirect } = useContext(AuthContext);
+  const { data: comics, isLoading: Loading } = useGetGeneralLatestComic();
+  const { isAuthenticated, loginWithRedirect, isLoading } = useContext(AuthContext);
 
+  if(Loading) return <ReactLoading type="spin" color='blue' className='loading' />
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
   return (

--- a/frontend/app/src/components/model/mypage/Profile.js
+++ b/frontend/app/src/components/model/mypage/Profile.js
@@ -46,7 +46,7 @@ const Profile = () => {
             ))}
           </div>
           <div className={profile['detail-area']}>
-            <Link to={`/profile_edit/${user.id}`} className={profile.button}>プロフィールを編集する</Link>
+            <Link to={`/my-profile/${user.id}`} className={profile.button}>プロフィールを編集する</Link>
           </div>
           <div className={profile['detail-area-count']}>
             <div className={profile.list}>

--- a/frontend/app/src/components/model/profile/MyProfile.js
+++ b/frontend/app/src/components/model/profile/MyProfile.js
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import PasswordChange from './PasswordChange';
+import ProfileEdit from './ProfileEdit';
+import subMenu from "../../../css/ui/subMenu.module.css";
+import mypage from "../../../css/mypage.module.css";
+import { AiFillHome, AiOutlineUser, AiFillUnlock } from "react-icons/ai";
+
+const MyProfile = () => {
+  const [tabIndex, setTabIndex] = useState(0);
+  const color = { color: 'red' }
+
+  return (
+    <div className={mypage.wrapper}>
+      <div className={subMenu["top-list"]}>
+        <div className={subMenu.title}>
+          <span className={subMenu.home}>
+            <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
+          </span>
+          <span>
+            <Link to='/mypage' className={subMenu["home-link"]}><span> / マイページ</span></Link>
+          </span>
+          <span> / プロフィール編集</span>
+        </div>
+      </div>
+      <div className={mypage.menu}>
+        <Tabs selectedIndex={tabIndex} onSelect={ (index) => setTabIndex(index) }>
+          <TabList className={mypage["menu-list"]}>
+            <Tab style={ tabIndex === 0 ? color : null } className={mypage["menu-list-in"]}>
+              <div>プロフィール情報</div>
+              <div className={mypage["menu-icon"]}><AiOutlineUser /></div>
+            </Tab>
+            <Tab style={ tabIndex === 1 ? color : null } className={mypage["menu-list-in"]}>
+              <div>パスワード変更</div>
+              <div className={mypage["menu-icon"]}><AiFillUnlock /></div>
+            </Tab>
+          </TabList>
+
+          <TabPanel>
+            <ProfileEdit />
+          </TabPanel>
+          <TabPanel>
+            <PasswordChange />
+          </TabPanel>
+        </Tabs>
+      </div>
+    </div>
+  );
+};
+
+export default MyProfile;

--- a/frontend/app/src/components/model/profile/PasswordChange.js
+++ b/frontend/app/src/components/model/profile/PasswordChange.js
@@ -1,0 +1,56 @@
+import axios from "axios";
+import { useForm } from "react-hook-form";
+
+const PasswordChange = () => {
+  const onSubmit = async (data) => {
+    await axios.post('https://dev-mqrxqmfa.us.auth0.com/dbconnections/change_password', data, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    .catch((error) => {
+      console.error(error.response.data);
+    });
+    alert(`確認メールが送信されました！`);
+    navigate("/");
+  };
+
+  const { handleSubmit, register, formState: { errors } } = useForm({
+    criteriaMode: "all"
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <div>メールアドレス</div>
+        { errors.email &&
+          <div>【！メールアドレスを入力してください】</div> 
+        }
+        <input
+          {...register('email', {
+            required: true
+          })}
+        />
+      </div>
+        <input
+          type='hidden'
+          defaultValue={ `${process.env.REACT_APP_AUTH0_CLIENT_ID}` }
+          {...register('client_id', {
+            required: true
+          })}
+        />
+        <input
+          type='hidden'
+          defaultValue={ `${process.env.REACT_APP_AUTH0_CONNECTION}` }
+          {...register('connection', {
+            required: true
+          })}
+        />
+        <div>
+            <button type="submit">この内容で登録する</button>
+          </div>
+    </form>
+  );
+};
+
+export default PasswordChange;

--- a/frontend/app/src/components/model/profile/PasswordChange.js
+++ b/frontend/app/src/components/model/profile/PasswordChange.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { useForm } from "react-hook-form";
+import form from "../../../css/ui/form.module.css";
 
 const PasswordChange = () => {
   const onSubmit = async (data) => {
@@ -12,7 +13,6 @@ const PasswordChange = () => {
       console.error(error.response.data);
     });
     alert(`確認メールが送信されました！`);
-    navigate("/");
   };
 
   const { handleSubmit, register, formState: { errors } } = useForm({
@@ -20,18 +20,21 @@ const PasswordChange = () => {
   });
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <div>
-        <div>メールアドレス</div>
-        { errors.email &&
-          <div>【！メールアドレスを入力してください】</div> 
-        }
-        <input
-          {...register('email', {
-            required: true
-          })}
-        />
-      </div>
+    <div className={form.wrapper}>
+      <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
+        <div className={form["form-text"]}>
+          <div className={form["form-label"]}>パスワード変更のリンクを受信するメールアドレス</div>
+          { errors.email &&
+            <div className={form.errors}>【！メールアドレスを入力してください】</div> 
+          }
+          <input
+            className={form["form-input"]}
+            placeholder='メールアドレスを入力してください'
+            {...register('email', {
+              required: true
+            })}
+          />
+        </div>
         <input
           type='hidden'
           defaultValue={ `${process.env.REACT_APP_AUTH0_CLIENT_ID}` }
@@ -46,10 +49,11 @@ const PasswordChange = () => {
             required: true
           })}
         />
-        <div>
-            <button type="submit">この内容で登録する</button>
-          </div>
-    </form>
+        <div className={form["form-text"]}>
+            <button className={form["form-submit"]} type="submit">送信する</button>
+        </div>
+      </form>
+    </div>
   );
 };
 

--- a/frontend/app/src/components/model/profile/ProfileEdit.js
+++ b/frontend/app/src/components/model/profile/ProfileEdit.js
@@ -1,10 +1,9 @@
 import { useContext } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useParams, Link } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useUser } from "../../../hooks/useUser";
 import { AuthContext } from "../../../providers/AuthGuard";
 import form from "../../../css/ui/form.module.css";
-import { AiFillHome } from "react-icons/ai";
 import { BsFillReplyFill } from "react-icons/bs";
 import axios from "axios";
 import ReactLoading from "react-loading";
@@ -48,17 +47,6 @@ const ProfileEdit = () => {
 
   return (
     <div className={subMenu.wrapper}>
-      <div className={subMenu["top-list"]}>
-        <div className={subMenu.title}>
-          <span className={subMenu.home}>
-            <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
-          </span>
-          <span>
-            <Link to='/mypage' className={subMenu["home-link"]}><span> / マイページ</span></Link>
-          </span>
-          <span> / プロフィール編集</span>
-        </div>
-      </div>
       <div className={subMenu.content}>
         <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
           <div className={form["form-text"]}>

--- a/frontend/app/src/providers/AuthGuard.js
+++ b/frontend/app/src/providers/AuthGuard.js
@@ -4,7 +4,7 @@ import { useAuth0 } from "@auth0/auth0-react";
 export const AuthContext = createContext();
 
 export const AuthGuardProvider = ({children}) => {
-  const { isAuthenticated,loginWithRedirect,logout,getAccessTokenSilently, user } = useAuth0();
+  const { isAuthenticated,loginWithRedirect,logout,getAccessTokenSilently, user, isLoading } = useAuth0();
   const [ token, setToken ] = useState('');
 
     const getToken = async () => {
@@ -21,7 +21,7 @@ export const AuthGuardProvider = ({children}) => {
     }, []);
     
   return (
-    <AuthContext.Provider value={{ isAuthenticated, loginWithRedirect, logout, token, user }}>
+    <AuthContext.Provider value={{ isAuthenticated, loginWithRedirect, logout, token, user, isLoading }}>
       { children }
     </AuthContext.Provider>
   );

--- a/frontend/app/src/providers/protectedRoute.js
+++ b/frontend/app/src/providers/protectedRoute.js
@@ -1,0 +1,11 @@
+import { withAuthenticationRequired } from "@auth0/auth0-react";
+import ReactLoading from "react-loading";
+
+const ProtectedRoute = ({ component, ...args }) => {
+  const Cp = withAuthenticationRequired(component, {
+    onRedirecting: () => <ReactLoading type="spin" color='blue' className='loading' />
+  });
+  return <Cp {...args} />
+};
+
+export default ProtectedRoute;

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -16,3 +16,4 @@ export { default as ComicNew } from '../components/model/mypage/ComicNew';
 export { default as Profile } from '../components/model/mypage/Profile';
 export { default as ComicPost } from '../components/model/mypage/ComicPost';
 export { default as Page404 } from '../components/error/Page404';
+export { default as MyProfile } from '../components/model/profile/MyProfile';

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -1,10 +1,10 @@
 import { Routes, Route } from 'react-router-dom';
+import ProtectedRoute from '../providers/protectedRoute';
 import {
   Home,
   TermsOfService, 
   PrivacyPolicy, 
-  MyPage, 
-  ProfileEdit, 
+  MyPage,
   ScenePost, 
   ScenePostNew, 
   ComicEdit, 
@@ -23,19 +23,18 @@ const Routers = () => {
       <Route path='/' element={ <Home /> } />
       <Route path='/terms-of-service' element={ <TermsOfService /> } />
       <Route path='/privacy-policy' element={ <PrivacyPolicy /> } />
-      <Route path='/mypage/' element={ <MyPage /> } />
-      {/* <Route path='/profile_edit/:user_id' element={ <ProfileEdit /> } /> */}
-      <Route path='/comic/:comic_id/:comic_title' element={ <ScenePost /> } />
-      <Route path='/comic/:comic_id/:comic_title/scene_post_new' element={ <ScenePostNew /> } />
-      <Route path='/scene_post/:comic_title/:scene_post_id' element={ <ScenePostShow /> } />
-      <Route path='/scene_post/:comic_id/:comic_title/:scene_post_id/scene_post_edit' element={ <ScenePostEdit /> } />
-      <Route path='/comic/:comic_id/:comic_title/comic_edit' element={ <ComicEdit /> } />
+      <Route path='/mypage/' element={ <ProtectedRoute component={MyPage}/> } />
+      <Route path='/comic/:comic_id/:comic_title' element={ <ProtectedRoute component={ScenePost}/> } />
+      <Route path='/comic/:comic_id/:comic_title/scene_post_new' element={ <ProtectedRoute component={ScenePostNew}/> } />
+      <Route path='/scene_post/:comic_title/:scene_post_id' element={ <ProtectedRoute component={ScenePostShow}/> } />
+      <Route path='/scene_post/:comic_id/:comic_title/:scene_post_id/scene_post_edit' element={ <ProtectedRoute component={ScenePostEdit}/> } />
+      <Route path='/comic/:comic_id/:comic_title/comic_edit' element={ <ProtectedRoute component={ComicEdit}/> } />
       <Route path='/general_scene_post/:comic_title/:comic_id' element={ <GeneralScenePost /> } />
       <Route path='/general_scene_post/:comic_title/general_scene_post_show/:scene_post_id/' element={ <GeneralScenePostShow /> } />
       <Route path='/general_scene_post/general_scene_post_show/:scene_post_id/' element={ <GeneralScenePostShow /> } />
       <Route path='/comic' element={ <GeneralComic /> } />
       <Route path='*' element={ <Page404 /> } />
-      <Route path='/my-profile/:user_id' element={ <MyProfile /> } />
+      <Route path='/my-profile/:user_id' element={ <ProtectedRoute component={MyProfile}/> } />
     </Routes>
   );
 };

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -13,7 +13,8 @@ import {
   GeneralScenePost, 
   GeneralComic,
   GeneralScenePostShow,
-  Page404
+  Page404,
+  MyProfile
 } from './Pages';
 
 const Routers = () => {
@@ -34,6 +35,7 @@ const Routers = () => {
       <Route path='/general_scene_post/general_scene_post_show/:scene_post_id/' element={ <GeneralScenePostShow /> } />
       <Route path='/comic' element={ <GeneralComic /> } />
       <Route path='*' element={ <Page404 /> } />
+      <Route path='/my-profile' element={ <MyProfile /> } />
     </Routes>
   );
 };

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -24,7 +24,7 @@ const Routers = () => {
       <Route path='/terms-of-service' element={ <TermsOfService /> } />
       <Route path='/privacy-policy' element={ <PrivacyPolicy /> } />
       <Route path='/mypage/' element={ <MyPage /> } />
-      <Route path='/profile_edit/:user_id' element={ <ProfileEdit /> } />
+      {/* <Route path='/profile_edit/:user_id' element={ <ProfileEdit /> } /> */}
       <Route path='/comic/:comic_id/:comic_title' element={ <ScenePost /> } />
       <Route path='/comic/:comic_id/:comic_title/scene_post_new' element={ <ScenePostNew /> } />
       <Route path='/scene_post/:comic_title/:scene_post_id' element={ <ScenePostShow /> } />
@@ -35,7 +35,7 @@ const Routers = () => {
       <Route path='/general_scene_post/general_scene_post_show/:scene_post_id/' element={ <GeneralScenePostShow /> } />
       <Route path='/comic' element={ <GeneralComic /> } />
       <Route path='*' element={ <Page404 /> } />
-      <Route path='/my-profile' element={ <MyProfile /> } />
+      <Route path='/my-profile/:user_id' element={ <MyProfile /> } />
     </Routes>
   );
 };


### PR DESCRIPTION
【実装したこと】
「バックエンド」
なし
「フロントエンド」
１　auth0を用いて、ユーザーのパスワードを変更するロジックを実装しました。
２　プロフィール設定画面をタブ化し、パスワードの再設定画面とユーザー情報の設定画面に切り分けました。
３　未ログインユーザーがログインユーザーのみが閲覧できるurlに訪れた時に、auth0のログインページにリダイレクトするよう、実装しました。
４　auth0でログインした際に、ローディング画面が表示されるように実装しました。
【なぜこの変更をしたのか】
１　パスワードの変更をできるようにしておかないと、ユーザーにとって、不便なアプリになってしまう
２　それぞれの画面で設定画面を分けた方が、UIの向上になると思います
３　もしも未ログインユーザーがログインユーザーのページにurlベタ打ちなどで飛んでしまった場合に、エラーが表示されてしまい、ユーザビリティが良くありません。
それに、ログインしていないユーザーがログインしているユーザーの画面に飛べてしまうのもセキュリティ上良くありません
４　ログインした際にホーム画面に戻る仕様にしているが、一瞬だが、ログインする前のレイアウトが表示されてしまい、UIが良くないので追加しました