### PR TITLE
scene_postテーブルにサブタイトルのカラムを追加しました

### DIFF
--- a/.github/workflows/mbg.yml
+++ b/.github/workflows/mbg.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
         ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} 'cd MangaBestGram-app &&
-        git pull origin 12_change-information-auth0:main &&
+        git pull origin 13_scene-post-add-column:main &&
         docker-compose down --rmi all &&
         docker rmi $(docker images -q)
         cd frontend &&

--- a/backend/app/controllers/api/v1/user/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/user/scene_posts_controller.rb
@@ -35,10 +35,10 @@ class Api::V1::User::ScenePostsController < SecuredController
   end
 
   def scene_post_params
-    params.permit(:scene_title, :scene_date, :scene_content, :scene_image, :scene_number).merge(user_id: @current_user.id)
+    params.permit(:scene_title, :scene_date, :scene_content, :scene_image, :scene_number, :sub_title).merge(user_id: @current_user.id)
   end
 
   def scene_post_update_params
-    params.permit(:scene_title, :scene_date, :scene_content, :scene_image, :scene_number)
+    params.permit(:scene_title, :scene_date, :scene_content, :scene_image, :scene_number, :sub_title)
   end
 end

--- a/backend/app/controllers/api/v1/user/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/user/scene_posts_controller.rb
@@ -35,7 +35,8 @@ class Api::V1::User::ScenePostsController < SecuredController
   end
 
   def scene_post_params
-    params.permit(:scene_title, :scene_date, :scene_content, :scene_image, :scene_number, :sub_title).merge(user_id: @current_user.id)
+    params.permit(:scene_title, :scene_date, :scene_content, :scene_image, :scene_number, :sub_title).
+      merge(user_id: @current_user.id)
   end
 
   def scene_post_update_params

--- a/backend/app/serializers/general/scene_post_serializer.rb
+++ b/backend/app/serializers/general/scene_post_serializer.rb
@@ -1,6 +1,6 @@
 class General::ScenePostSerializer
   include JSONAPI::Serializer
-  attributes :id, :scene_title, :scene_date, :scene_content, :scene_image, :user_id, :comic_id, :scene_number
+  attributes :id, :scene_title, :scene_date, :scene_content, :scene_image, :user_id, :comic_id, :scene_number, :sub_title
 
   # rubocop:disable Style/ClassVars
   def initialize(resource, options = {})

--- a/backend/app/serializers/scene_post_serializer.rb
+++ b/backend/app/serializers/scene_post_serializer.rb
@@ -1,6 +1,6 @@
 class ScenePostSerializer
   include JSONAPI::Serializer
-  attributes :id, :scene_title, :scene_date, :scene_content, :scene_image, :user_id, :comic_id, :scene_number
+  attributes :id, :scene_title, :scene_date, :scene_content, :scene_image, :user_id, :comic_id, :scene_number, :sub_title
 
   attribute :scene_post_user_name do |object|
     object.user.name.to_s

--- a/backend/db/migrate/20221205075750_add_sub_title_to_scene_posts.rb
+++ b/backend/db/migrate/20221205075750_add_sub_title_to_scene_posts.rb
@@ -1,0 +1,5 @@
+class AddSubTitleToScenePosts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :scene_posts, :sub_title, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_15_030120) do
+ActiveRecord::Schema.define(version: 2022_12_05_075750) do
 
   create_table "comics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2022_11_15_030120) do
     t.bigint "user_id", null: false
     t.bigint "comic_id", null: false
     t.integer "scene_number"
+    t.string "sub_title"
     t.index ["comic_id"], name: "index_scene_posts_on_comic_id"
     t.index ["user_id"], name: "index_scene_posts_on_user_id"
   end

--- a/frontend/app/src/components/model/general/GeneralScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralScenePost.js
@@ -18,6 +18,7 @@ const GeneralScenePost = () => {
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
   if(general_loading) return <ReactLoading type="spin" color='blue' className='loading' />
+  console.log(scene_posts)
 
   return (
     <div className={subMenu.wrapper}>
@@ -38,10 +39,10 @@ const GeneralScenePost = () => {
               <GeneralScenePostCard
                 key={index}
                 scenePostId={scene_post.id}
+                scenePostSubTitle={scene_post.attributes.sub_title}
                 scenePostUserImage={scene_post.attributes.scene_post_user_image.url}
                 scenePostUserName={scene_post.attributes.scene_post_user_name}
-                scenePostTitle={scene_post.attributes.scene_title}
-                scenePostDate={scene_post.attributes.scene_date}
+                scenePostNumber={scene_post.attributes.scene_number}
                 scenePostImage={scene_post.attributes.scene_image.url}
                 favorite={scene_post.attributes.favorite}
                 comicTitle={comic_title}
@@ -54,10 +55,10 @@ const GeneralScenePost = () => {
               <GeneralScenePostCard
                 key={index}
                 scenePostId={scene_post.id}
+                scenePostSubTitle={scene_post.attributes.subTitle}
                 scenePostUserImage={scene_post.attributes.scenePostUserImage.url}
                 scenePostUserName={scene_post.attributes.scenePostUserName}
-                scenePostTitle={scene_post.attributes.sceneTitle}
-                scenePostDate={scene_post.attributes.sceneDate}
+                scenePostNumber={scene_post.attributes.sceneNumber}
                 scenePostImage={scene_post.attributes.sceneImage.url}
                 favorite={scene_post.attributes.favorite}
                 comicTitle={comic_title}

--- a/frontend/app/src/components/model/general/GeneralScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralScenePost.js
@@ -18,7 +18,6 @@ const GeneralScenePost = () => {
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
   if(general_loading) return <ReactLoading type="spin" color='blue' className='loading' />
-  console.log(scene_posts)
 
   return (
     <div className={subMenu.wrapper}>

--- a/frontend/app/src/components/model/general/GeneralScenePostShow.js
+++ b/frontend/app/src/components/model/general/GeneralScenePostShow.js
@@ -4,7 +4,7 @@ import ReactLoading from "react-loading";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
-import { BsBookFill, BsFillReplyFill, BsFillPencilFill, BsCalendar3, BsNewspaper, BsFillJournalBookmarkFill } from "react-icons/bs";
+import { BsBookFill, BsFillReplyFill, BsFillPencilFill, BsCalendar3, BsNewspaper, BsFillJournalBookmarkFill, BsReceipt } from "react-icons/bs";
 import noimage from "../../../image/default.png";
 
 const GeneralScenePostShow = () => {
@@ -39,7 +39,11 @@ const GeneralScenePostShow = () => {
           <div className={scenePostShow.article}>
             <p className={scenePostShow["comic-title"]}><span className={scenePostShow["bs-book-fill"]}><BsBookFill /></span>{ scene_post.data.attributes.scenePostComicTitle }</p>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-pencil-fill"]}><BsFillPencilFill /></span>【シーンのタイトル】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-pencil-fill"]}><BsFillPencilFill /></span>【シーンのサブタイトル】</p>
+              <div>{ scene_post.data.attributes.subTitle }</div>
+            </div>
+            <div className={scenePostShow["detail-area"]}>
+              <p className={scenePostShow.detail}><span className={scenePostShow["bs-receipt"]}><BsReceipt /></span>【シーンの内容】</p>
               <div>{ scene_post.data.attributes.sceneTitle }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
@@ -51,7 +55,7 @@ const GeneralScenePostShow = () => {
               <div>{ scene_post.data.attributes.sceneDate }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-newspaper"]}><BsNewspaper /></span>【シーンの内容】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["bs-newspaper"]}><BsNewspaper /></span>【シーンの詳細・感想】</p>
               <div>{ scene_post.data.attributes.sceneContent }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>

--- a/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
@@ -9,10 +9,10 @@ import { AuthContext } from "../../../../providers/AuthGuard";
 
 const GeneralScenePostCard = ({
   scenePostId,
+  scenePostSubTitle,
   scenePostUserImage,
   scenePostUserName,
-  scenePostTitle,
-  scenePostDate,
+  scenePostNumber,
   scenePostImage,
   favorite,
   comicTitle
@@ -49,12 +49,12 @@ const GeneralScenePostCard = ({
             />
           )}
           <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-book-fill"]}><BsBookFill /></span>【シーン名】</p>
-            <div>{ scenePostTitle }</div>
+            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-book-fill"]}><BsBookFill /></span>【サブタイトル】</p>
+            <div>{ scenePostSubTitle }</div>
           </div>
           <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの日付】</p>
-            <div>{ scenePostDate }</div>
+            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの話数】話</p>
+            <div>{ scenePostNumber }話</div>
           </div>
           <div className={generalScenePostCss["detail-area-link"]}>
             <Link to={`/general_scene_post/${comicTitle}/general_scene_post_show/${scenePostId}`} className={generalScenePostCss["link-show"]} >シーンを見る</Link>

--- a/frontend/app/src/components/model/scene_post/ScenePost.js
+++ b/frontend/app/src/components/model/scene_post/ScenePost.js
@@ -42,7 +42,7 @@ const ScenePost = () => {
               <div className={scenePost.list}>
                 <div className={scenePost["detail-area"]}>
                     <p className={scenePost.detail}><span className={scenePost["bs-book-fill"]}><BsBookFill /></span>【サブタイトル】</p>
-                    <div>{ scene_post.scene_title }</div>
+                    <div>{ scene_post.sub_title }</div>
                 </div>
                 <div className={scenePost["detail-area"]}>
                   <p className={scenePost.detail}><span className={scenePost["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【話数】</p>

--- a/frontend/app/src/components/model/scene_post/ScenePostNew.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostNew.js
@@ -26,6 +26,7 @@ const ScenePostNew = () => {
     formData.append("scene_content", data.scene_content);
     formData.append("scene_date", data.scene_date);
     formData.append("scene_image", data.scene_image[0]);
+    formData.append("sub_title", data.sub_title);
 
     await axios.post(`${process.env.REACT_APP_DEV_API_URL}/user/comics/${comic_id}/scene_posts`, formData, {
       headers: {
@@ -69,6 +70,19 @@ const ScenePostNew = () => {
       </div>
       <div className={subMenu.content}>
         <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
+          <div className={form["form-text"]}>
+            <div className={form["form-label"]}>サブタイトル</div>
+            { errors.sub_title &&
+              <div className={form.errors}>【！サブタイトルが空欄です】</div> 
+            }
+            <input
+              className={form["form-input"]}
+              placeholder="サブタイトルを入力してください"
+              {...register('sub_title', {
+                required: true
+              })}
+            />
+          </div>
           <div className={form["form-text"]}>
             <div className={form["form-label"]}>好きなシーン名</div>
             { errors.scene_title &&

--- a/frontend/app/src/components/model/scene_post/ScenePostShow.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostShow.js
@@ -3,7 +3,7 @@ import { useScenePost } from "../../../hooks/useScenePost";
 import ReactLoading from "react-loading";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import { AiFillHome } from "react-icons/ai";
-import { BsBookFill, BsFillReplyFill, BsFillPencilFill, BsCalendar3, BsNewspaper, BsFillJournalBookmarkFill } from "react-icons/bs";
+import { BsBookFill, BsFillReplyFill, BsFillPencilFill, BsCalendar3, BsNewspaper, BsFillJournalBookmarkFill, BsReceipt } from "react-icons/bs";
 import noimage from "../../../image/default.png";
 
 const ScenePostShow = () => {
@@ -14,6 +14,7 @@ const ScenePostShow = () => {
   const { data: scene_post, isLoading } = useShowScenePost(scene_post_id);
 
   if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
+  console.log(scene_post)
 
   return (
     <div className={scenePostShow.wrapper}>
@@ -26,7 +27,7 @@ const ScenePostShow = () => {
             <Link to='/mypage' className={scenePostShow["home-link"]}><span>/ マイページ</span></Link>
           </span>
           <span className={scenePostShow["scene-title"]}>
-            / { scene_post.scene_title }の詳細画面
+            / { scene_post.sub_title }の詳細画面
           </span>
         </div>
       </div>
@@ -38,7 +39,11 @@ const ScenePostShow = () => {
           <div className={scenePostShow.article}>
             <p className={scenePostShow["comic-title"]}><span className={scenePostShow["bs-book-fill"]}><BsBookFill /></span>{ comic_title }</p>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-pencil-fill"]}><BsFillPencilFill /></span>【シーンのタイトル】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-pencil-fill"]}><BsFillPencilFill /></span>【シーンのサブタイトル】</p>
+              <div>{ scene_post.sub_title }</div>
+            </div>
+            <div className={scenePostShow["detail-area"]}>
+              <p className={scenePostShow.detail}><span className={scenePostShow["bs-receipt"]}><BsReceipt /></span>【シーンの内容】</p>
               <div>{ scene_post.scene_title }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
@@ -46,11 +51,11 @@ const ScenePostShow = () => {
               <div>{ scene_post.scene_number }話</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-calender-3"]}><BsCalendar3 /></span>【そのシーンを見た日付】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["bs-calender-3"]}><BsCalendar3 /></span>【シーンを見た日付】</p>
               <div>{ scene_post.scene_date }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-newspaper"]}><BsNewspaper /></span>【シーンの内容】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["bs-newspaper"]}><BsNewspaper /></span>【シーンの詳細・感想】</p>
               <div>{ scene_post.scene_content }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>

--- a/frontend/app/src/css/model/scene_post/scenePostShow.module.css
+++ b/frontend/app/src/css/model/scene_post/scenePostShow.module.css
@@ -91,6 +91,13 @@
   margin-right: 7px;
 }
 
+.bs-receipt {
+  color: hotpink;
+  font-size: 20px;
+  vertical-align: -4px;
+  margin-right: 7px;
+}
+
 .bs-fill-journal-bookmark-fill {
   color: green;
   font-size: 20px;


### PR DESCRIPTION
【実装したこと】
「バックエンド」
１　scene_postテーブルにsub_titleカラムを追加しました
２　scene_postの各コントローラに、sub_titleのカラムの記述を追加しました
「フロントエンド」
１　シーンの一覧・全ユーザーが閲覧できるシーン一覧・シーンの詳細を表示させる画面に、追加したsub_titleカラムを表示させるように実装
２　シーン一覧・全ユーザーが閲覧できるシーン一覧に表示させる２つの表示名をサブタイトルとシーンの話数に変更
【なぜこの変更をしたか】
「バックエンド・フロントエンド」
１　漫画のシーンを投稿する時に各漫画のシーンのサブタイトルを表示した方が、ユーザビリティの向上につながると思いました
自分の好きなシーンを探す時にも、探しやすくなります
「フロントエンド」
２　ユーザーが一番最初に目にする場所に一番分かりやすいシーンのサブタイトルとシーンの話数を表示させれば、ユーザビリティの向上につながります
