### PR TITLE
検索機能と並び替え機能を実装

### DIFF
--- a/.github/workflows/mbg.yml
+++ b/.github/workflows/mbg.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
         ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} 'cd MangaBestGram-app &&
-        git pull origin 13_scene-post-add-column:main &&
+        git pull origin 14_search-sort-function:main &&
         docker-compose down --rmi all &&
         docker rmi $(docker images -q)
         cd frontend &&

--- a/backend/app/controllers/api/v1/comics_controller.rb
+++ b/backend/app/controllers/api/v1/comics_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ComicsController < ApplicationController
   def index
-    comics = Comic.all
+    comics = Comic.all.order(updated_at: :desc)
     render_json = ComicSerializer.new(comics).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/comics_controller.rb
+++ b/backend/app/controllers/api/v1/comics_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ComicsController < ApplicationController
   def index
-    comics = Comic.all.order(updated_at: :desc)
+    comics = Comic.all.order(id: :desc)
     render_json = ComicSerializer.new(comics).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/general/comics_controller.rb
+++ b/backend/app/controllers/api/v1/general/comics_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::General::ComicsController < SecuredController
   def index
-    comics = Comic.all.order(updated_at: :desc)
+    comics = Comic.all.order(id: :desc)
     render_json = General::ComicSerializer.new(comics).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/general/comics_controller.rb
+++ b/backend/app/controllers/api/v1/general/comics_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::General::ComicsController < SecuredController
   def index
-    comics = Comic.all
+    comics = Comic.all.order(updated_at: :desc)
     render_json = General::ComicSerializer.new(comics).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/general/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/general/scene_posts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::General::ScenePostsController < SecuredController
   def index
-    scene_posts = ScenePost.where(comic_id: params[:comic_id]).order(updated_at: :desc)
+    scene_posts = ScenePost.where(comic_id: params[:comic_id]).order(id: :desc)
     render_json = General::ScenePostSerializer.new(scene_posts, current_user: @current_user).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/general/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/general/scene_posts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::General::ScenePostsController < SecuredController
   def index
-    scene_posts = ScenePost.where(comic_id: params[:comic_id])
+    scene_posts = ScenePost.where(comic_id: params[:comic_id]).order(updated_at: :desc)
     render_json = General::ScenePostSerializer.new(scene_posts, current_user: @current_user).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/scene_posts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ScenePostsController < ApplicationController
   def index
-    scene_posts = ScenePost.where(comic_id: params[:comic_id]).order(updated_at: :desc)
+    scene_posts = ScenePost.where(comic_id: params[:comic_id]).order(id: :desc)
     render_json = ScenePostSerializer.new(scene_posts).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/scene_posts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ScenePostsController < ApplicationController
   def index
-    scene_posts = ScenePost.where(comic_id: params[:comic_id])
+    scene_posts = ScenePost.where(comic_id: params[:comic_id]).order(updated_at: :desc)
     render_json = ScenePostSerializer.new(scene_posts).serializable_hash.to_json
     render json: render_json
   end

--- a/backend/app/controllers/api/v1/user/comics_controller.rb
+++ b/backend/app/controllers/api/v1/user/comics_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::User::ComicsController < SecuredController
   before_action :set_comic, only: %i(update destroy show)
 
   def index
-    comics = @current_user.comics.all.order(updated_at: :desc)
+    comics = @current_user.comics.all.order(id: :desc)
     render json: comics
   end
 

--- a/backend/app/controllers/api/v1/user/comics_controller.rb
+++ b/backend/app/controllers/api/v1/user/comics_controller.rb
@@ -2,12 +2,11 @@ class Api::V1::User::ComicsController < SecuredController
   before_action :set_comic, only: %i(update destroy show)
 
   def index
-    comics = @current_user.comics.all
+    comics = @current_user.comics.all.order(updated_at: :desc)
     render json: comics
   end
 
   def show
-    @comic
     render json: @comic
   end
 

--- a/backend/app/controllers/api/v1/user/favorites_controller.rb
+++ b/backend/app/controllers/api/v1/user/favorites_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::User::FavoritesController < SecuredController
   def index
-    favorites = Favorite.where(user_id: @current_user.id).pluck(:scene_post_id)
+    favorites = Favorite.where(user_id: @current_user.id).order(updated_at: :desc).pluck(:scene_post_id)
     favorite_list = ScenePost.find(favorites)
     render_json = ScenePostSerializer.new(favorite_list).serializable_hash.to_json
     render json: render_json

--- a/backend/app/controllers/api/v1/user/favorites_controller.rb
+++ b/backend/app/controllers/api/v1/user/favorites_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::User::FavoritesController < SecuredController
   def index
-    favorites = Favorite.where(user_id: @current_user.id).order(updated_at: :desc).pluck(:scene_post_id)
+    favorites = Favorite.where(user_id: @current_user.id).order(id: :desc).pluck(:scene_post_id)
     favorite_list = ScenePost.find(favorites)
     render_json = ScenePostSerializer.new(favorite_list).serializable_hash.to_json
     render json: render_json

--- a/backend/app/controllers/api/v1/user/favorites_controller.rb
+++ b/backend/app/controllers/api/v1/user/favorites_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::User::FavoritesController < SecuredController
   def index
-    favorites = Favorite.where(user_id: @current_user.id).order(id: :desc).pluck(:scene_post_id)
+    favorites = Favorite.where(user_id: @current_user.id).order(updated_at: :desc).pluck(:scene_post_id)
     favorite_list = ScenePost.find(favorites)
     render_json = ScenePostSerializer.new(favorite_list).serializable_hash.to_json
     render json: render_json

--- a/backend/app/controllers/api/v1/user/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/user/scene_posts_controller.rb
@@ -7,7 +7,6 @@ class Api::V1::User::ScenePostsController < SecuredController
   end
 
   def show
-    @scene_post
     render json: @scene_post
   end
 

--- a/backend/app/controllers/api/v1/user/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/user/scene_posts_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::User::ScenePostsController < SecuredController
   before_action :set_scene_post, only: %i(show update destroy)
 
   def index
-    posts = @current_user.comics.find_by!(id: params[:comic_id]).scene_posts.all
+    posts = @current_user.comics.find_by!(id: params[:comic_id]).scene_posts.all.order(updated_at: :desc)
     render json: posts
   end
 

--- a/backend/app/controllers/api/v1/user/scene_posts_controller.rb
+++ b/backend/app/controllers/api/v1/user/scene_posts_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::User::ScenePostsController < SecuredController
   before_action :set_scene_post, only: %i(show update destroy)
 
   def index
-    posts = @current_user.comics.find_by!(id: params[:comic_id]).scene_posts.all.order(updated_at: :desc)
+    posts = @current_user.comics.find_by!(id: params[:comic_id]).scene_posts.all.order(id: :desc)
     render json: posts
   end
 

--- a/backend/app/controllers/api/v1/user/users_controller.rb
+++ b/backend/app/controllers/api/v1/user/users_controller.rb
@@ -5,7 +5,6 @@ class Api::V1::User::UsersController < SecuredController
   end
 
   def show
-    @current_user
     render json: @current_user
   end
 

--- a/frontend/app/src/components/model/general/GeneralComic.js
+++ b/frontend/app/src/components/model/general/GeneralComic.js
@@ -6,7 +6,7 @@ import generalComic from "../../../css/model/general/generalComic.module.css";
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
 import { BsBookFill, BsJournalBookmarkFill, BsSearch } from "react-icons/bs";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 const GeneralComic = () => {
   const { useGetGeneralComic } = useGeneralComic();
@@ -25,6 +25,40 @@ const GeneralComic = () => {
     );
   }
 
+  const [ sort, setSort ] = useState({});
+
+  const sortedData = useMemo(() => {
+    let _sortedData = data;
+    if (sort.key) {
+      _sortedData = _sortedData.sort((a, b) => {
+        a = a[sort.key];
+        b = b[sort.key];
+
+        if (a === b) {
+          return 0;
+        }
+        if (a > b) {
+          return 1 * sort.order;
+        }
+        if (a < b) {
+          return -1 * sort.order;
+        }
+      });
+    }
+    return _sortedData;
+  }, [sort, data]);
+
+  const handleSort = (key) => {
+    if (sort.key === key) {
+      setSort({...sort, order: -sort.order});
+    } else {
+      setSort({
+        key: key,
+        order: 1
+      })
+    } 
+  };
+
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
   return (
@@ -38,6 +72,9 @@ const GeneralComic = () => {
         </div>
       </div>
       <div className={generalComic.count}>【投稿数】 {comics.data.length}件</div>
+      <div className={generalComic.sort}>
+        <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え </button>
+      </div>
       <div className={generalComic.search}>
         <span className={generalComic["bs-search"]}><BsSearch /></span>
         <input
@@ -51,7 +88,7 @@ const GeneralComic = () => {
         <div className={generalComic["detail-result"]}>検索結果がありません</div>
       ) }
       <div className={generalComic["main-content"]}>
-        {data.map((comic) => (
+        {sortedData.map((comic) => (
           <div key={comic.id} className={generalComic.content}>
             <div className={generalComic["innner-content"]}>
               <div className={generalComic.list}>

--- a/frontend/app/src/components/model/general/GeneralComic.js
+++ b/frontend/app/src/components/model/general/GeneralComic.js
@@ -5,11 +5,25 @@ import noimage from "../../../image/default.png";
 import generalComic from "../../../css/model/general/generalComic.module.css";
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
-import { BsBookFill, BsJournalBookmarkFill } from "react-icons/bs";
+import { BsBookFill, BsJournalBookmarkFill, BsSearch } from "react-icons/bs";
+import { useState } from "react";
 
 const GeneralComic = () => {
   const { useGetGeneralComic } = useGeneralComic();
   const { data: comics, isLoading } = useGetGeneralComic();
+
+  let data = comics === undefined ? [{ length: 0 }] : comics.data;
+
+  const [searchText, setSearchText] = useState('');
+
+  const searchKeywords = searchText.trim().match(/[^\s]+/g);
+  if (searchKeywords !== null) {
+    data = comics.data.filter((comic) =>
+      searchKeywords.every(
+        (kw) => comic.attributes.title.indexOf(kw) !== -1
+      )
+    );
+  }
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
@@ -23,8 +37,21 @@ const GeneralComic = () => {
           <span>/ 投稿一覧</span>
         </div>
       </div>
+      <div className={generalComic.count}>【投稿数】 {comics.data.length}件</div>
+      <div className={generalComic.search}>
+        <span className={generalComic["bs-search"]}><BsSearch /></span>
+        <input
+          className={generalComic["search-text"]}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder={'漫画のタイトルを検索'}
+        />
+      </div>
+      { data.length === 0 && (
+        <div className={generalComic["detail-result"]}>検索結果がありません</div>
+      ) }
       <div className={generalComic["main-content"]}>
-        {comics.data.map((comic) => (
+        {data.map((comic) => (
           <div key={comic.id} className={generalComic.content}>
             <div className={generalComic["innner-content"]}>
               <div className={generalComic.list}>

--- a/frontend/app/src/components/model/general/GeneralScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralScenePost.js
@@ -6,7 +6,7 @@ import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
 import GeneralScenePostCard from "./ui/GeneralScenePostCard";
 import { AuthContext } from "../../../providers/AuthGuard";
-import { useContext, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { BsSearch } from "react-icons/bs";
 
 const GeneralScenePost = () => {
@@ -41,6 +41,73 @@ const GeneralScenePost = () => {
     );
   }
 
+  const [ sort, setSort ] = useState({});
+  const [ generalSort, setGeneralSort ] = useState({});
+
+  const sortedData = useMemo(() => {
+    let _sortedData = data;
+    if (sort.key) {
+      _sortedData = _sortedData.sort((a, b) => {
+        a = a[sort.key];
+        b = b[sort.key];
+
+        if (a === b) {
+          return 0;
+        }
+        if (a > b) {
+          return 1 * sort.order;
+        }
+        if (a < b) {
+          return -1 * sort.order;
+        }
+      });
+    }
+    return _sortedData;
+  }, [sort, data]);
+
+  const handleSort = (key) => {
+    if (sort.key === key) {
+      setSort({...sort, order: -sort.order});
+    } else {
+      setSort({
+        key: key,
+        order: 1
+      })
+    } 
+  };
+
+  const sortedGeneralData = useMemo(() => {
+    let _sortedGeneralData = generalData;
+    if (generalSort.key) {
+      _sortedGeneralData = _sortedGeneralData.sort((a, b) => {
+        a = a[generalSort.key];
+        b = b[generalSort.key];
+
+        if (a === b) {
+          return 0;
+        }
+        if (a > b) {
+          return 1 * generalSort.order;
+        }
+        if (a < b) {
+          return -1 * generalSort.order;
+        }
+      });
+    }
+    return _sortedGeneralData;
+  }, [generalSort, generalData]);
+
+  const handleGeneralSort = (key) => {
+    if (generalSort.key === key) {
+      setGeneralSort({...generalSort, order: -generalSort.order});
+    } else {
+      setGeneralSort({
+        key: key,
+        order: 1
+      })
+    } 
+  };
+
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
   if(general_loading) return <ReactLoading type="spin" color='blue' className='loading' />
 
@@ -59,6 +126,9 @@ const GeneralScenePost = () => {
       <div className={generalScenePostCss.count}>【投稿数】 {scene_posts.data.length}件</div>
       {isAuthenticated ? (
         <>
+          <div className={generalScenePostCss.sort}>
+            <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え </button>
+          </div>
           <div className={generalScenePostCss.search}>
             <span className={generalScenePostCss["bs-search"]}><BsSearch /></span>
             <input
@@ -72,7 +142,7 @@ const GeneralScenePost = () => {
             <div className={generalScenePostCss["detail-result"]}>検索結果がありません</div>
           ) }
           <div className={generalScenePostCss["main-content"]}>
-            {data.map((scene_post, index) => (
+            {sortedData.map((scene_post, index) => (
               <GeneralScenePostCard
                 key={index}
                 scenePostId={scene_post.id}
@@ -89,6 +159,9 @@ const GeneralScenePost = () => {
         </>
       ) : (
         <>
+          <div className={generalScenePostCss.sort}>
+            <button className={generalSort.key === 'id' ? generalSort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleGeneralSort('id')}>並び替え </button>
+          </div>
           <div className={generalScenePostCss.search}>
             <span className={generalScenePostCss["bs-search"]}><BsSearch /></span>
             <input
@@ -102,7 +175,7 @@ const GeneralScenePost = () => {
             <div className={generalScenePostCss["detail-result"]}>検索結果がありません</div>
           ) }
           <div className={generalScenePostCss["main-content"]}>
-            {generalData.map((scene_post, index) => (
+            {sortedGeneralData.map((scene_post, index) => (
               <GeneralScenePostCard
                 key={index}
                 scenePostId={scene_post.id}

--- a/frontend/app/src/components/model/general/GeneralScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralScenePost.js
@@ -6,7 +6,8 @@ import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
 import GeneralScenePostCard from "./ui/GeneralScenePostCard";
 import { AuthContext } from "../../../providers/AuthGuard";
-import { useContext } from "react";
+import { useContext, useState } from "react";
+import { BsSearch } from "react-icons/bs";
 
 const GeneralScenePost = () => {
   const { comic_id, comic_title } = useParams();
@@ -15,6 +16,30 @@ const GeneralScenePost = () => {
 
   const { data: scene_posts, isLoading } = useGetGeneralScenePost(comic_id);
   const { data: general_scene_posts, isLoading: general_loading } = useGetLoginGeneralScenePost(comic_id);
+
+  let generalData = scene_posts === undefined ? [{ length: 0 }] : scene_posts.data;
+  let data = general_scene_posts === undefined ? [{ length: 0 }] : general_scene_posts.data;
+
+  const [searchText, setSearchText] = useState('');
+  const [searchGeneralText, setSearchGeneralText] = useState('');
+
+  const searchKeywords = searchText.trim().match(/[^\s]+/g);
+  if (searchKeywords !== null) {
+    data = general_scene_posts.data.filter((general_scene_post) =>
+      searchKeywords.every(
+        (kw) => general_scene_post.attributes.sub_title.indexOf(kw) !== -1
+      )
+    );
+  }
+
+  const searchGeneralKeywords = searchGeneralText.trim().match(/[^\s]+/g);
+  if (searchGeneralKeywords !== null) {
+    generalData = scene_posts.data.filter((scene_post) =>
+      searchGeneralKeywords.every(
+        (kw) => scene_post.attributes.subTitle.indexOf(kw) !== -1
+      )
+    );
+  }
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
   if(general_loading) return <ReactLoading type="spin" color='blue' className='loading' />
@@ -31,10 +56,23 @@ const GeneralScenePost = () => {
           </span>
         </div>
       </div>
-      <div className={generalScenePostCss["main-content"]}>
-        {isAuthenticated ? (
-          <>
-            {general_scene_posts.data.map((scene_post, index) => (
+      <div className={generalScenePostCss.count}>【投稿数】 {scene_posts.data.length}件</div>
+      {isAuthenticated ? (
+        <>
+          <div className={generalScenePostCss.search}>
+            <span className={generalScenePostCss["bs-search"]}><BsSearch /></span>
+            <input
+              className={generalScenePostCss["search-text"]}
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              placeholder={'サブタイトルを検索'}
+            />
+          </div>
+          { data.length === 0 && (
+            <div className={generalScenePostCss["detail-result"]}>検索結果がありません</div>
+          ) }
+          <div className={generalScenePostCss["main-content"]}>
+            {data.map((scene_post, index) => (
               <GeneralScenePostCard
                 key={index}
                 scenePostId={scene_post.id}
@@ -47,10 +85,24 @@ const GeneralScenePost = () => {
                 comicTitle={comic_title}
               />
             ))}
-          </>
-        ) : (
-          <>
-            {scene_posts.data?.map((scene_post, index) => (
+          </div>
+        </>
+      ) : (
+        <>
+          <div className={generalScenePostCss.search}>
+            <span className={generalScenePostCss["bs-search"]}><BsSearch /></span>
+            <input
+              className={generalScenePostCss["search-text"]}
+              value={searchGeneralText}
+              onChange={(e) => setSearchGeneralText(e.target.value)}
+              placeholder={'サブタイトルを検索'}
+            />
+          </div>
+          { generalData.length === 0 && (
+            <div className={generalScenePostCss["detail-result"]}>検索結果がありません</div>
+          ) }
+          <div className={generalScenePostCss["main-content"]}>
+            {generalData.map((scene_post, index) => (
               <GeneralScenePostCard
                 key={index}
                 scenePostId={scene_post.id}
@@ -63,9 +115,9 @@ const GeneralScenePost = () => {
                 comicTitle={comic_title}
               />
             ))}
-          </>
-        )}
-      </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
@@ -53,7 +53,7 @@ const GeneralScenePostCard = ({
             <div>{ scenePostSubTitle }</div>
           </div>
           <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの話数】話</p>
+            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの話数】</p>
             <div>{ scenePostNumber }話</div>
           </div>
           <div className={generalScenePostCss["detail-area-link"]}>

--- a/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
@@ -1,7 +1,7 @@
 import { useContext, useState } from "react";
 import generalScenePostCss from '../../../../css/model/general/generalScenePostCss.module.css';
 import noimage from "../../../../image/default.png";
-import { BsBookFill, BsJournalBookmarkFill } from "react-icons/bs";
+import { BsBookFill, BsJournalBookmarkFill, BsBookmark  } from "react-icons/bs";
 import UnFavoriteButton from "../../../ui/UnFavoriteButton";
 import FavoriteButton from "../../../ui/FavoriteButton";
 import { Link } from "react-router-dom";
@@ -40,13 +40,14 @@ const GeneralScenePostCard = ({
               )}
             </>
           ) : (
-            <input
+            <button
+              className={generalScenePostCss.favorite}
               type='submit'
               value={`お気に入り`}
               onClick={() => {
                 loginWithRedirect();
               }}
-            />
+            ><BsBookmark /></button>
           )}
           <div className={generalScenePostCss["detail-area"]}>
             <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-book-fill"]}><BsBookFill /></span>【サブタイトル】</p>

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -24,7 +24,6 @@ const ComicPost = () => {
   }
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
-  console.log(comics)
 
   return (
     <div className={comicPost.wrapper}>

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -62,7 +62,7 @@ const ComicPost = () => {
   return (
     <div className={comicPost.wrapper}>
       <div className={comicPost.count}>【投稿数】 {comics.length}件</div>
-        <button className={sort.key === 'updated_at' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('updated_at')}>並び替え </button>
+      <button className={sort.key === 'updated_at' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('updated_at')}>並び替え </button>
       <div className={comicPost.search}>
         <span className={comicPost["bs-search"]}><BsSearch /></span>
         <input

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -27,7 +27,7 @@ const ComicPost = () => {
 
   return (
     <div className={comicPost.wrapper}>
-      <div className={comicPost.count}>【投稿数】 : {comics.length}件</div>
+      <div className={comicPost.count}>【投稿数】 {comics.length}件</div>
       <div className={comicPost.search}>
         <span className={comicPost["bs-search"]}><BsSearch /></span>
         <input

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -1,10 +1,10 @@
+import { useMemo, useState } from 'react';
 import comicPost from '../../../css/model/comicPost.module.css';
 import { Link } from 'react-router-dom';
 import { useComic } from '../../../hooks/useComic';
 import ReactLoading from "react-loading";
 import noimage from "../../../image/default.png";
 import { BsBookFill, BsJournalBookmarkFill, BsSearch } from "react-icons/bs";
-import { useState } from 'react';
 
 const ComicPost = () => {
   const { useGetComic } = useComic();
@@ -23,11 +23,46 @@ const ComicPost = () => {
     );
   }
 
+  const [ sort, setSort ] = useState({});
+
+  const sortedData = useMemo(() => {
+    let _sortedData = data;
+    if (sort.key) {
+      _sortedData = _sortedData.sort((a, b) => {
+        a = a[sort.key];
+        b = b[sort.key];
+
+        if (a === b) {
+          return 0;
+        }
+        if (a > b) {
+          return 1 * sort.order;
+        }
+        if (a < b) {
+          return -1 * sort.order;
+        }
+      });
+    }
+    return _sortedData;
+  }, [sort, data]);
+
+  const handleSort = (key) => {
+    if (sort.key === key) {
+      setSort({...sort, order: -sort.order});
+    } else {
+      setSort({
+        key: key,
+        order: 1
+      })
+    } 
+  };
+
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
   return (
     <div className={comicPost.wrapper}>
       <div className={comicPost.count}>【投稿数】 {comics.length}件</div>
+        <button className={sort.key === 'updated_at' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('updated_at')}>並び替え </button>
       <div className={comicPost.search}>
         <span className={comicPost["bs-search"]}><BsSearch /></span>
         <input
@@ -41,7 +76,7 @@ const ComicPost = () => {
         <div className={comicPost["detail-result"]}>検索結果がありません</div>
       ) }
       <div className={comicPost["main-content"]}>
-        {data.map((comic) => (
+        {sortedData.map((comic) => (
           <div key={comic.id} className={comicPost.content}>
             <div className={comicPost["innner-content"]}>
               <div className={comicPost["outer-image"]}>

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -3,19 +3,46 @@ import { Link } from 'react-router-dom';
 import { useComic } from '../../../hooks/useComic';
 import ReactLoading from "react-loading";
 import noimage from "../../../image/default.png";
-import { BsBookFill, BsJournalBookmarkFill } from "react-icons/bs";
+import { BsBookFill, BsJournalBookmarkFill, BsSearch } from "react-icons/bs";
+import { useState } from 'react';
 
 const ComicPost = () => {
   const { useGetComic } = useComic();
   const { data: comics, isLoading } = useGetComic();
 
+  let data = comics === undefined ? [{ length: 0 }] : comics;
+
+  const [searchText, setSearchText] = useState('');
+
+  const searchKeywords = searchText.trim().match(/[^\s]+/g);
+  if (searchKeywords !== null) {
+    data = comics.filter((comic) =>
+      searchKeywords.every(
+        (kw) => comic.title.indexOf(kw) !== -1
+      )
+    );
+  }
+
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  console.log(comics)
 
   return (
     <div className={comicPost.wrapper}>
       <div className={comicPost.count}>【投稿数】 : {comics.length}件</div>
+      <div className={comicPost.search}>
+        <span className={comicPost["bs-search"]}><BsSearch /></span>
+        <input
+          className={comicPost["search-text"]}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder={'漫画のタイトルを検索'}
+        />
+      </div>
+      { data.length === 0 && (
+        <div className={comicPost["detail-result"]}>検索結果がありません</div>
+      ) }
       <div className={comicPost["main-content"]}>
-        {comics?.map((comic) => (
+        {data.map((comic) => (
           <div key={comic.id} className={comicPost.content}>
             <div className={comicPost["innner-content"]}>
               <div className={comicPost["outer-image"]}>

--- a/frontend/app/src/components/model/mypage/Favorite.js
+++ b/frontend/app/src/components/model/mypage/Favorite.js
@@ -29,7 +29,7 @@ const Favorite = () => {
 
   return (
     <div className={favorite.wrapper}>
-      <div className={favorite.count}>【投稿数】 : {favorites.data.length}件</div>
+      <div className={favorite.count}>【投稿数】 {favorites.data.length}件</div>
       <div className={favorite.search}>
         <span className={favorite["bs-search"]}><BsSearch /></span>
         <input

--- a/frontend/app/src/components/model/mypage/Favorite.js
+++ b/frontend/app/src/components/model/mypage/Favorite.js
@@ -4,30 +4,57 @@ import { Link } from 'react-router-dom';
 import noimage from "../../../image/default.png";
 import generalScenePostCss from '../../../css/model/general/generalScenePostCss.module.css';
 import favorite from '../../../css/model/mypage/favorite.module.css';
-import { BsBookFill, BsJournalBookmarkFill } from "react-icons/bs";
+import { BsBookFill, BsJournalBookmarkFill, BsSearch } from "react-icons/bs";
+import { useState } from "react";
 
 const Favorite = () => {
   const { useGetFavorite } = useFavorite();
   const { data: favorites, isLoading } = useGetFavorite();
 
+  let data = favorites === undefined ? [{ length: 0 }] : favorites.data;
+
+  const [searchText, setSearchText] = useState('');
+
+  const searchKeywords = searchText.trim().match(/[^\s]+/g);
+  if (searchKeywords !== null) {
+    data = favorites.data.filter((favorite) =>
+      searchKeywords.every(
+        (kw) => favorite.attributes.sub_title.indexOf(kw) !== -1
+      )
+    );
+  }
+
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  console.log(favorites)
 
   return (
     <div className={favorite.wrapper}>
       <div className={favorite.count}>【投稿数】 : {favorites.data.length}件</div>
+      <div className={favorite.search}>
+        <span className={favorite["bs-search"]}><BsSearch /></span>
+        <input
+          className={favorite["search-text"]}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder={'サブタイトルを検索'}
+        />
+      </div>
+      { data.length === 0 && (
+        <div className={favorite["detail-result"]}>検索結果がありません</div>
+      ) }
       <div className={favorite['main-content']}>
-        {favorites.data.map((favorite) => (
+        {data.map((favorite) => (
           <div key={favorite.id} className={generalScenePostCss.content}>
             <div className={generalScenePostCss["innner-content"]}>
               <div className={generalScenePostCss.list}>
                 <div className={generalScenePostCss["user-name"]}><img className={generalScenePostCss["user-image"]} src={ favorite.attributes.scene_post_user_image } alt='画像' onError={(e) => e.target.src = noimage} />{ favorite.attributes.scene_post_user_name }</div>
                 <div className={generalScenePostCss["detail-area"]}>
-                  <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-book-fill"]}><BsBookFill /></span>【シーン名】</p>
-                  <div>{ favorite.attributes.scene_title }</div>
+                  <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-book-fill"]}><BsBookFill /></span>【サブタイトル】</p>
+                  <div>{ favorite.attributes.sub_title }</div>
                 </div>
                 <div className={generalScenePostCss["detail-area"]}>
-                  <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの日付】</p>
-                  <div>{ favorite.attributes.scene_date }</div>
+                  <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの話数】</p>
+                  <div>{ favorite.attributes.scene_number }話</div>
                 </div>
                 <div className={generalScenePostCss["detail-area-link"]}>
                   <Link to={`/general_scene_post/general_scene_post_show/${favorite.id}`} className={generalScenePostCss["link-show"]} >シーンを見る</Link>

--- a/frontend/app/src/components/model/scene_post/ScenePost.js
+++ b/frontend/app/src/components/model/scene_post/ScenePost.js
@@ -4,13 +4,27 @@ import { Link, useParams } from 'react-router-dom';
 import scenePost from '../../../css/model/scene_post/scenePost.module.css';
 import { AiFillHome } from "react-icons/ai";
 import noimage from "../../../image/default.png";
-import { BsBookFill, BsJournalBookmarkFill } from "react-icons/bs";
+import { BsBookFill, BsJournalBookmarkFill, BsSearch } from "react-icons/bs";
+import { useState } from 'react';
 
 const ScenePost = () => {
   const { comic_id, comic_title } = useParams();
   const { useGetScenePost } = useScenePost();
 
   const { data: scene_posts, isLoading } = useGetScenePost(comic_id);
+
+  let data = scene_posts === undefined ? [{ length: 0 }] : scene_posts;
+
+  const [searchText, setSearchText] = useState('');
+
+  const searchKeywords = searchText.trim().match(/[^\s]+/g);
+  if (searchKeywords !== null) {
+    data = scene_posts.filter((scene_post) =>
+      searchKeywords.every(
+        (kw) => scene_post.sub_title.indexOf(kw) !== -1
+      )
+    );
+  }
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
@@ -29,11 +43,24 @@ const ScenePost = () => {
           </span>
         </div>
       </div>
+      <div className={scenePost.count}>【投稿数】 {scene_posts.length}件</div>
+      <div className={scenePost.search}>
+        <span className={scenePost["bs-search"]}><BsSearch /></span>
+        <input
+          className={scenePost["search-text"]}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder={'サブタイトルを検索'}
+        />
+      </div>
       <button className={scenePost.link}>
         <Link to={`/comic/${comic_id}/${comic_title}/scene_post_new`}>新規のシーンを投稿する</Link>
       </button>
+      { data.length === 0 && (
+        <div className={scenePost["detail-result"]}>検索結果がありません</div>
+      ) }
       <div className={scenePost["main-content"]}>
-        {scene_posts?.map((scene_post) => (
+        {data.map((scene_post) => (
           <div key={scene_post.id} className={scenePost.content}>
             <div className={scenePost["innner-content"]}>
               <div className={scenePost["outer-image"]}>

--- a/frontend/app/src/components/model/scene_post/ScenePost.js
+++ b/frontend/app/src/components/model/scene_post/ScenePost.js
@@ -5,7 +5,7 @@ import scenePost from '../../../css/model/scene_post/scenePost.module.css';
 import { AiFillHome } from "react-icons/ai";
 import noimage from "../../../image/default.png";
 import { BsBookFill, BsJournalBookmarkFill, BsSearch } from "react-icons/bs";
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 const ScenePost = () => {
   const { comic_id, comic_title } = useParams();
@@ -26,6 +26,40 @@ const ScenePost = () => {
     );
   }
 
+  const [ sort, setSort ] = useState({});
+
+  const sortedData = useMemo(() => {
+    let _sortedData = data;
+    if (sort.key) {
+      _sortedData = _sortedData.sort((a, b) => {
+        a = a[sort.key];
+        b = b[sort.key];
+
+        if (a === b) {
+          return 0;
+        }
+        if (a > b) {
+          return 1 * sort.order;
+        }
+        if (a < b) {
+          return -1 * sort.order;
+        }
+      });
+    }
+    return _sortedData;
+  }, [sort, data]);
+
+  const handleSort = (key) => {
+    if (sort.key === key) {
+      setSort({...sort, order: -sort.order});
+    } else {
+      setSort({
+        key: key,
+        order: 1
+      })
+    } 
+  };
+
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
   return (
@@ -44,6 +78,9 @@ const ScenePost = () => {
         </div>
       </div>
       <div className={scenePost.count}>【投稿数】 {scene_posts.length}件</div>
+      <div className={scenePost.sort}>
+        <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え </button>
+      </div>
       <div className={scenePost.search}>
         <span className={scenePost["bs-search"]}><BsSearch /></span>
         <input
@@ -60,7 +97,7 @@ const ScenePost = () => {
         <div className={scenePost["detail-result"]}>検索結果がありません</div>
       ) }
       <div className={scenePost["main-content"]}>
-        {data.map((scene_post) => (
+        {sortedData.map((scene_post) => (
           <div key={scene_post.id} className={scenePost.content}>
             <div className={scenePost["innner-content"]}>
               <div className={scenePost["outer-image"]}>

--- a/frontend/app/src/css/App.css
+++ b/frontend/app/src/css/App.css
@@ -29,3 +29,30 @@ button {
 .loading {
   margin: 250px auto;
 }
+
+.button {
+  border: none;
+  border: 2px solid #a9a9a9;
+  font-size: 18px;
+  border-radius: 5px;
+  text-align: center;
+  cursor: pointer;
+  padding: 6px;
+  margin-bottom: 10px;
+  background-color: #f0f8ff;
+}
+
+  .button::after {
+    content: '(新しい順)';
+    font-weight: bold;
+  }
+
+  .active.asc::after {
+    content: '(新しい順)';
+    font-weight: bold;
+  }
+
+  .active.desc:after {
+    content: '(古い順)';
+    font-weight: bold;
+  }

--- a/frontend/app/src/css/App.css
+++ b/frontend/app/src/css/App.css
@@ -48,11 +48,11 @@ button {
   }
 
   .active.asc::after {
-    content: '(新しい順)';
+    content: '(古い順)';
     font-weight: bold;
   }
 
   .active.desc:after {
-    content: '(古い順)';
+    content: '(新しい順)';
     font-weight: bold;
   }

--- a/frontend/app/src/css/model/comicPost.module.css
+++ b/frontend/app/src/css/model/comicPost.module.css
@@ -9,6 +9,33 @@
   font-weight: bold;
 }
 
+.search {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.search-text {
+  height: 40px;
+  background-color: #f0f8ff;
+  border: 2px solid #a9a9a9;
+  font-size: 20px;
+  border-radius: 5px;
+}
+
+.bs-search {
+  color: palevioletred;
+  margin-right: 4px;
+  font-size: 29px;
+  vertical-align: -5px;
+}
+
+.detail-result {
+  text-align: center;
+  margin-top: 80px;
+  font-weight: bold;
+  font-size: 25px;
+}
+
 .main-content {
   justify-content: space-between;
   display: flex;

--- a/frontend/app/src/css/model/general/generalComic.module.css
+++ b/frontend/app/src/css/model/general/generalComic.module.css
@@ -4,8 +4,13 @@
 
 .count {
   margin-bottom: 20px;
+  margin-left: 20px;
   font-size: 20px;
   font-weight: bold;
+}
+
+.sort {
+  margin-left: 20px;
 }
 
 .search {

--- a/frontend/app/src/css/model/general/generalComic.module.css
+++ b/frontend/app/src/css/model/general/generalComic.module.css
@@ -2,6 +2,39 @@
   width: 100%;
 }
 
+.count {
+  margin-bottom: 20px;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.search {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.search-text {
+  height: 40px;
+  background-color: #f0f8ff;
+  border: 2px solid #a9a9a9;
+  font-size: 20px;
+  border-radius: 5px;
+}
+
+.bs-search {
+  color: palevioletred;
+  margin-right: 4px;
+  font-size: 29px;
+  vertical-align: -5px;
+}
+
+.detail-result {
+  text-align: center;
+  margin-top: 80px;
+  font-weight: bold;
+  font-size: 25px;
+}
+
 .main-content {
   padding: 121px;
   justify-content: space-between;

--- a/frontend/app/src/css/model/general/generalScenePostCss.module.css
+++ b/frontend/app/src/css/model/general/generalScenePostCss.module.css
@@ -34,6 +34,39 @@
   flex-wrap: wrap;
 }
 
+.count {
+  margin-bottom: 20px;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.search {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.search-text {
+  height: 40px;
+  background-color: #f0f8ff;
+  border: 2px solid #a9a9a9;
+  font-size: 20px;
+  border-radius: 5px;
+}
+
+.bs-search {
+  color: palevioletred;
+  margin-right: 4px;
+  font-size: 29px;
+  vertical-align: -5px;
+}
+
+.detail-result {
+  text-align: center;
+  margin-top: 80px;
+  font-weight: bold;
+  font-size: 25px;
+}
+
 .content {
   width: 49%;
   margin-top: 20px;

--- a/frontend/app/src/css/model/general/generalScenePostCss.module.css
+++ b/frontend/app/src/css/model/general/generalScenePostCss.module.css
@@ -1,32 +1,3 @@
-.wrapper {
-  width: 100%;
-}
-
-.title {
-  font-size: 17px;
-  padding: 15px;
-  font-weight: bold;
-}
-
-.home {
-  align-items: center;
-  margin-right: 5px;
-}
-
-.home-link {
-  vertical-align: middle;
-  color: rgba(92,102,111,0.6);
-}
-
-.home-link:hover {
-  opacity: 0.5;
-}
-
-.react-icons {
-  vertical-align: -3px;
-  margin-right: 3px;
-}
-
 .main-content {
   padding: 30px;
   justify-content: space-between;
@@ -36,8 +7,13 @@
 
 .count {
   margin-bottom: 20px;
+  margin-left: 20px;
   font-size: 20px;
   font-weight: bold;
+}
+
+.sort {
+  margin-left: 20px;
 }
 
 .search {

--- a/frontend/app/src/css/model/mypage/favorite.module.css
+++ b/frontend/app/src/css/model/mypage/favorite.module.css
@@ -8,6 +8,33 @@
   font-weight: bold;
 }
 
+.search {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.search-text {
+  height: 40px;
+  background-color: #f0f8ff;
+  border: 2px solid #a9a9a9;
+  font-size: 20px;
+  border-radius: 5px;
+}
+
+.bs-search {
+  color: palevioletred;
+  margin-right: 4px;
+  font-size: 29px;
+  vertical-align: -5px;
+}
+
+.detail-result {
+  text-align: center;
+  margin-top: 80px;
+  font-weight: bold;
+  font-size: 25px;
+}
+
 .main-content {
   justify-content: space-between;
   display: flex;

--- a/frontend/app/src/css/model/mypage/favorite.module.css
+++ b/frontend/app/src/css/model/mypage/favorite.module.css
@@ -3,6 +3,7 @@
 }
 
 .count {
+  margin-bottom: 20px;
   margin-top: 20px;
   font-size: 20px;
   font-weight: bold;

--- a/frontend/app/src/css/model/scene_post/scenePost.module.css
+++ b/frontend/app/src/css/model/scene_post/scenePost.module.css
@@ -4,8 +4,13 @@
 
 .count {
   margin-bottom: 20px;
+  margin-left: 20px;
   font-size: 20px;
   font-weight: bold;
+}
+
+.sort {
+  margin-left: 20px;
 }
 
 .search {

--- a/frontend/app/src/css/model/scene_post/scenePost.module.css
+++ b/frontend/app/src/css/model/scene_post/scenePost.module.css
@@ -2,6 +2,39 @@
   width: 100%;
 }
 
+.count {
+  margin-bottom: 20px;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.search {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.search-text {
+  height: 40px;
+  background-color: #f0f8ff;
+  border: 2px solid #a9a9a9;
+  font-size: 20px;
+  border-radius: 5px;
+}
+
+.bs-search {
+  color: palevioletred;
+  margin-right: 4px;
+  font-size: 29px;
+  vertical-align: -5px;
+}
+
+.detail-result {
+  text-align: center;
+  margin-top: 80px;
+  font-weight: bold;
+  font-size: 25px;
+}
+
 .title {
   font-size: 17px;
   padding: 15px;
@@ -34,7 +67,7 @@
 
 .link {
   text-decoration: none;
-  background-color: white;
+  background-color: #f0f8ff;
   border: 2px solid black;
   border-radius: 15px;
   padding: 10px 20px;

--- a/frontend/app/src/css/ui/subMenu.module.css
+++ b/frontend/app/src/css/ui/subMenu.module.css
@@ -46,7 +46,7 @@
   }
 
   .react-icons {
-    vertical-align: -2px;
+    vertical-align: -1px;
     margin-right: 2px;
   }
 }

--- a/frontend/app/src/hooks/useComic.js
+++ b/frontend/app/src/hooks/useComic.js
@@ -11,7 +11,7 @@ export const useComic = () => {
       queryKey: 'comic',
       queryFn: () => comic.getComic(token),
       staleTime: 300000,
-      cacheTime: 300000,
+      cacheTime: 0,
     });
   };
 


### PR DESCRIPTION
【実装したこと】
「バックエンド」
１　投稿を表示させる順番を最新の順に表示させるためにorderメソッドを追加
２　orderメソッドのキーをidに変更
「フロントエンド」
１　各投稿一覧を表示するコンポーネントに検索機能を追加
２　お気に入りを除く各投稿一覧を表示するコンポーネントにSort機能を追加
３　非ログイン時のお気に入りアイコンのレイアウトをログイン時と同じにしました
４　全ユーザーが閲覧できる画面に、投稿数の表示を追加しました
【なぜこの変更をしたか】
「バックエンド」
１　古い順から表示されるよりも、最新の順から表示される方が、ユーザビリティに優れていると思いました。一般的な投稿型のアプリでも、最新の順に投稿が表示される方が多いのでその基準に合わせました。
２　idの順にすることで、編集をしたとしてもその投稿の順番が入れ替わることのないようにしました。投稿の編集をする度に最新の投稿の順に入れ替わるのはユーザビリティに優れてないと思います。
「フロントエンド」
１　検索機能を追加することで、ユーザーが目的の投稿を見つけやすくするメリットがあります。
２　Sort機能を追加することで、ユーザーの好みの順で、投稿を表示できるようになります。投稿が多い場合に、古い投稿まで辿り着く時間を短縮できます。
３　お気に入りアイコンが非ログイン時に初期状態のままだったので、ログイン時と同じレイアウトに修正しました。
４　投稿数の表示を追加することで、現在の投稿数を把握でき、ユーザビリティ向上につながります。

以上が変更した点になります。細かいレイアウトなどの調整は記載していませんが、気になる点があれば再度調整いたします。