### PR TITLE
ユーザーの一覧と詳細、シーン数の表示とお気に入り数の表示を実装

### DIFF
--- a/.github/workflows/mbg.yml
+++ b/.github/workflows/mbg.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
         ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} 'cd MangaBestGram-app &&
-        git pull origin 15_comment-function:main &&
+        git pull origin 16_user-list-function:main &&
         docker-compose down --rmi all &&
         docker rmi $(docker images -q)
         cd frontend &&

--- a/backend/app/controllers/api/v1/comments_controller.rb
+++ b/backend/app/controllers/api/v1/comments_controller.rb
@@ -4,4 +4,9 @@ class Api::V1::CommentsController < ApplicationController
     render_json = User::CommentSerializer.new(comments).serializable_hash.to_json
     render json: render_json
   end
+
+  def favorites_count
+    favorites = Favorite.where(scene_post_id: params[:scene_post_id]).all
+    render json: favorites
+  end
 end

--- a/backend/app/controllers/api/v1/user/comics_controller.rb
+++ b/backend/app/controllers/api/v1/user/comics_controller.rb
@@ -27,6 +27,11 @@ class Api::V1::User::ComicsController < SecuredController
     @comic.destroy!
   end
 
+  def scene_post_count
+    scene_posts = @current_user.scene_posts.all
+    render json: scene_posts
+  end
+
   private
 
   def comic_params

--- a/backend/app/controllers/api/v1/user_comics_controller.rb
+++ b/backend/app/controllers/api/v1/user_comics_controller.rb
@@ -3,4 +3,9 @@ class Api::V1::UserComicsController < ApplicationController
     user_comics = Comic.where(user_id: params[:user_id]).order(id: :desc)
     render json: user_comics
   end
+
+  def scene_post_count
+    scene_posts = ScenePost.where(user_id: params[:user_id]).all
+    render json: scene_posts
+  end
 end

--- a/backend/app/controllers/api/v1/user_comics_controller.rb
+++ b/backend/app/controllers/api/v1/user_comics_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::UserComicsController < ApplicationController
+  def index
+    user_comics = Comic.where(user_id: params[:user_id]).order(id: :desc)
+    render json: user_comics
+  end
+end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::UsersController < ApplicationController
   def index
-    user = User.all.order(id: :desc)
+    users = User.all.order(id: :desc)
+    render json: users
+  end
+
+  def show
+    user = User.find(params[:id])
     render json: user
   end
 end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,22 +1,6 @@
-class Api::V1::UsersController < SecuredController
-  skip_before_action :authorize_request, only: [:create]
-
-  def create
-    register_user
-  end
-
-  private
-
-  def user_params
-    params.require(:user).permit(:name, :introduction, :image, :url)
-  end
-
-  def register_user
-    authorization = AuthorizationService.new(request.headers)
-    user_name = user_params[:name]
-    user_introduction = user_params[:introduction]
-    user_image = user_params[:image]
-    user_url = user_params[:url]
-    @current_user = authorization.create_user(user_name, user_introduction, user_image, user_url)
+class Api::V1::UsersController < ApplicationController
+  def index
+    user = User.all.order(id: :desc)
+    render json: user
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -27,7 +27,11 @@ Rails.application.routes.draw do
       end
       resources :comics, only: [:index, :show], shallow: true do
         resources :scene_posts, only: [:index, :show], shallow: true do
-          resources :comments, only: [:index]
+          resources :comments, only: [:index] do
+            collection do
+              get 'favorites_count'
+            end
+          end
         end
         collection do
           get 'latest'

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -16,7 +16,11 @@ Rails.application.routes.draw do
         end
       end
       resources :users, only: [:index, :show], shallow: true do
-        resources :user_comics, only: [:index]
+        resources :user_comics, only: [:index] do
+          collection do
+            get 'scene_post_count'
+          end
+        end
       end
       resources :comics, only: [:index, :show], shallow: true do
         resources :scene_posts, only: [:index, :show], shallow: true do

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
           resources :scene_posts, only: [:index, :show]
         end
       end
-      resources :users, only: [:index]
+      resources :users, only: [:index, :show], shallow: true do
+        resources :user_comics, only: [:index]
+      end
       resources :comics, only: [:index, :show], shallow: true do
         resources :scene_posts, only: [:index, :show], shallow: true do
           resources :comments, only: [:index]

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
           resources :scene_posts, only: [:index, :show]
         end
       end
-      resources :users
+      resources :users, only: [:index]
       resources :comics, only: [:index, :show], shallow: true do
         resources :scene_posts, only: [:index, :show], shallow: true do
           resources :comments, only: [:index]

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
       namespace :user do
         resources :users, only: [:index, :update, :show]
         resources :comics, shallow: true do
+          collection do
+            get 'scene_post_count'
+          end
           resources :scene_posts, shallow: true do
             resources :comments, only: [:index, :create, :destroy]
           end

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -13,6 +13,7 @@
     "js-cookie": "^3.0.1",
     "moment": "^2.29.4",
     "react": "^18.2.0",
+    "react-burger-menu": "^3.0.8",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",
     "react-hook-form": "^7.38.0",

--- a/frontend/app/src/api/comic.js
+++ b/frontend/app/src/api/comic.js
@@ -66,5 +66,19 @@ export const comic = {
     .catch((error) => {
       console.error(error.res.data);
     });
+  },
+
+  getScenePostCount: async (token) => {
+    const res = await axios
+    .get(`${process.env.REACT_APP_DEV_API_URL}/user/comics/scene_post_count`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    return res.data;
   }
 };

--- a/frontend/app/src/api/favorite.js
+++ b/frontend/app/src/api/favorite.js
@@ -1,4 +1,5 @@
-import axios from "axios"
+import axios from "axios";
+import instance from "./instance";
 
 export const favorite = {
   getFavorite: async (token) => {
@@ -14,4 +15,13 @@ export const favorite = {
     });
     return res.data;
   },
+
+  getFavorites_count: async (scenePostId) => {
+    const res = await instance
+    .get(`/scene_posts/${scenePostId}/comments/favorites_count`)
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    return res.data;
+  }
 };

--- a/frontend/app/src/api/generalUser.js
+++ b/frontend/app/src/api/generalUser.js
@@ -1,0 +1,30 @@
+import instance from "./instance"
+
+export const generalUser = {
+  getGeneralUser: async () => {
+    const res = await instance
+    .get('/users')
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    return res.data
+  },
+
+  showGeneralUser: async (userId) => {
+    const res = await instance
+    .get(`/users/${userId}`)
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    return res.data
+  },
+
+  getGeneralUserComic: async (userId) => {
+    const res = await instance
+    .get(`/users/${userId}/user_comics`)
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    return res.data
+  }
+};

--- a/frontend/app/src/api/generalUser.js
+++ b/frontend/app/src/api/generalUser.js
@@ -26,5 +26,14 @@ export const generalUser = {
       console.error(error.res.data);
     });
     return res.data
+  },
+
+  getGeneralUserScenePostCount: async (userId) => {
+    const res = await instance
+    .get(`/users/${userId}/user_comics/scene_post_count`)
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    return res.data
   }
 };

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import header from '../css/header.module.css';
 import { Link } from 'react-router-dom';
 import { AuthContext } from '../providers/AuthGuard';
+import { FcVoicePresentation, FcClapperboard, FcImport, FcHome } from "react-icons/fc";
 
 const Header = () => {
   const { isAuthenticated, loginWithRedirect, logout } = useContext(AuthContext);
@@ -12,15 +13,18 @@ const Header = () => {
       <div className={header.list}>
         <ul className={header.ul}>
           <li className={header.li}>
-            <Link to='comic'><button className={header["nav-li-text"]}>投稿一覧</button></Link>
+            <Link to='/users'><button className={header["nav-li-text"]}><span className={header["react-icon"]}><FcVoicePresentation /></span>ユーザー一覧</button></Link>
+          </li>
+          <li className={header.li}>
+            <Link to='/comic'><button className={header["nav-comic"]}><span className={header["react-icon"]}><FcClapperboard /></span>漫画一覧</button></Link>
           </li>
             { isAuthenticated ?
               <li className={header.li}>
-                <button onClick={() => logout({ returnTo: window.location.origin })} className={header["nav-li-text"]}>ログアウト</button>
+                <button onClick={() => logout({ returnTo: window.location.origin })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcImport /></span>ログアウト</button>
               </li>
               :
               <li className={header.li}>
-                <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={header["nav-li-text"]}>新規登録/ログイン</button>
+                <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcHome /></span>新規登録/ログイン</button>
               </li>
             }
         </ul>

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -3,6 +3,7 @@ import header from '../css/header.module.css';
 import { Link } from 'react-router-dom';
 import { AuthContext } from '../providers/AuthGuard';
 import { FcVoicePresentation, FcClapperboard, FcImport, FcHome } from "react-icons/fc";
+import BurgerMenu from './ui/BurgerMenu';
 
 const Header = () => {
   const { isAuthenticated, loginWithRedirect, logout } = useContext(AuthContext);
@@ -12,21 +13,24 @@ const Header = () => {
       <Link to='/' className={header.logo}>MangaBestGram</Link>
       <div className={header.list}>
         <ul className={header.ul}>
+          <li className={header.side}>
+            <BurgerMenu />
+          </li>
           <li className={header.li}>
             <Link to='/users'><button className={header["nav-li-text"]}><span className={header["react-icon"]}><FcVoicePresentation /></span>ユーザー一覧</button></Link>
           </li>
           <li className={header.li}>
             <Link to='/comic'><button className={header["nav-comic"]}><span className={header["react-icon"]}><FcClapperboard /></span>漫画一覧</button></Link>
           </li>
-            { isAuthenticated ?
-              <li className={header.li}>
-                <button onClick={() => logout({ returnTo: window.location.origin })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcImport /></span>ログアウト</button>
-              </li>
-              :
-              <li className={header.li}>
-                <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcHome /></span>新規登録/ログイン</button>
-              </li>
-            }
+          { isAuthenticated ?
+            <li className={header.li}>
+              <button onClick={() => logout({ returnTo: window.location.origin })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcImport /></span>ログアウト</button>
+            </li>
+            :
+            <li className={header.li}>
+              <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcHome /></span>新規登録/ログイン</button>
+            </li>
+          }
         </ul>
       </div>
     </nav>

--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -8,7 +8,7 @@ import ReactLoading from "react-loading";
 import noimage from "../image/default.png"
 import { Link as Scroll } from 'react-scroll';
 import { BsChevronDoubleDown } from "react-icons/bs";
-import { FcReading, FcFile, FcCalendar, FcMms } from "react-icons/fc";
+import { FcReading, FcFile, FcCalendar, FcMms, FcHome } from "react-icons/fc";
 import moment from 'moment';
 
 const Home = () => {
@@ -28,11 +28,11 @@ const Home = () => {
           {
             isAuthenticated ?
             <div className={home["post-title"]}>
-              <Link to="/mypage" className={home["post-title-link"]} >マイページ</Link>
+              <Link to="/mypage" className={home["post-title-link"]} ><span className={home["react-icon"]}><FcHome /></span>マイページ</Link>
             </div>
             :
             <div className={home["post-title"]}>
-              <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={home["post-title-link"]}>ログイン/新規登録</button>
+              <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={home["post-title-link"]}><span className={home["react-icon"]}><FcHome /></span>ログイン/新規登録</button>
             </div>
           }
           </div>

--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -58,11 +58,11 @@ const Home = () => {
                 <div className={generalComic.list}>
                   <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />{ comic.attributes.comicUserName }</div>
                   <div className={generalComic["detail-area"]}>
-                    <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcReading /></span>【漫画名】</p>
+                    <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcReading /></span>漫画名</p>
                     <div>{ comic.attributes.title }</div>
                   </div>
                   <div className={generalComic["detail-area"]}>
-                    <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcFile /></span>【ジャンル】</p>
+                    <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcFile /></span>ジャンル</p>
                     <div>{ comic.attributes.genre }</div>
                   </div>
                   <div className={generalComic["detail-area-link"]}>

--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -7,15 +7,16 @@ import { useGeneralComic } from '../hooks/useGeneralComic';
 import ReactLoading from "react-loading";
 import noimage from "../image/default.png"
 import { Link as Scroll } from 'react-scroll';
-import { BsBookFill, BsJournalBookmarkFill, BsChevronDoubleDown, BsCalendar3 } from "react-icons/bs";
+import { BsChevronDoubleDown } from "react-icons/bs";
+import { FcReading, FcFile, FcCalendar, FcMms } from "react-icons/fc";
 import moment from 'moment';
 
 const Home = () => {
   const { useGetGeneralLatestComic } = useGeneralComic();
-  const { data: comics, isLoading: Loading } = useGetGeneralLatestComic();
+  const { data: comics, isLoading: comicLoading } = useGetGeneralLatestComic();
   const { isAuthenticated, loginWithRedirect, isLoading } = useContext(AuthContext);
 
-  if(Loading) return <ReactLoading type="spin" color='blue' className='loading' />
+  if(comicLoading) return <></>
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
   return (
@@ -57,20 +58,20 @@ const Home = () => {
                 <div className={generalComic.list}>
                   <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />{ comic.attributes.comicUserName }</div>
                   <div className={generalComic["detail-area"]}>
-                    <p className={generalComic.detail}><span className={generalComic["bs-book-fill"]}><BsBookFill /></span>【漫画名】</p>
+                    <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcReading /></span>【漫画名】</p>
                     <div>{ comic.attributes.title }</div>
                   </div>
                   <div className={generalComic["detail-area"]}>
-                    <p className={generalComic.detail}><span className={generalComic["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【ジャンル】</p>
+                    <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcFile /></span>【ジャンル】</p>
                     <div>{ comic.attributes.genre }</div>
                   </div>
                   <div className={generalComic["detail-area-link"]}>
-                    <Link to={`/general_scene_post/${comic.attributes.title}/${comic.id}`} className={generalComic["link-show"]} >シーンを見る</Link>
+                    <Link to={`/general_scene_post/${comic.attributes.title}/${comic.id}`} className={generalComic["link-show"]} ><span className={generalComic["react-icon"]}><FcMms /></span>シーンを見る</Link>
                   </div>
                 </div>
                 <div className={generalComic["outer-image"]}>
                   <div className={generalComic["detail-area-image"]}>
-                    <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["bs-calender-3"]}><BsCalendar3 /></span>{ moment(comic.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+                    <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["react-icon"]}><FcCalendar /></span>{ moment(comic.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
                     <img className={generalComic.image} src={ comic.attributes.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
                   </div>
                 </div>

--- a/frontend/app/src/components/MyPage.js
+++ b/frontend/app/src/components/MyPage.js
@@ -1,13 +1,14 @@
 import { useState } from "react";
 import mypage from "../css/mypage.module.css";
-import { AiFillHome, AiFillEdit, AiFillHeart, AiFillFileText, AiOutlineUser } from "react-icons/ai";
+import { AiFillHome } from "react-icons/ai";
+import { FcLike, FcClapperboard, FcVoicePresentation, FcAddImage } from "react-icons/fc";
 import { Link } from "react-router-dom";
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { ComicNew, ComicPost, Favorite, Profile } from "../route/Pages";
 
 const MyPage = () => {
   const [tabIndex, setTabIndex] = useState(2);
-  const color = { color: 'red' }
+  const color = { background: '#ffc0cb' }
 
   return (
     <div className={mypage.wrapper}>
@@ -19,19 +20,19 @@ const MyPage = () => {
           <TabList className={mypage["menu-list"]}>
             <Tab style={ tabIndex === 0 ? color : null } className={mypage["menu-list-in"]}>
               <div>新規投稿</div>
-              <div className={mypage["menu-icon"]}><AiFillEdit /></div>
+              <div className={mypage["menu-icon"]}><FcAddImage /></div>
             </Tab>
             <Tab style={ tabIndex === 1 ? color : null } className={mypage["menu-list-in"]}>
               <div>お気に入り</div>
-              <div className={mypage["menu-icon"]}><AiFillHeart /></div>
+              <div className={mypage["menu-icon"]}><FcLike /></div>
             </Tab>
             <Tab style={ tabIndex === 2 ? color : null } className={mypage["menu-list-in"]}>
               <div>投稿一覧</div>
-              <div className={mypage["menu-icon"]}><AiFillFileText /></div>
+              <div className={mypage["menu-icon"]}><FcClapperboard /></div>
             </Tab>
             <Tab style={ tabIndex === 3 ? color : null } className={mypage["menu-list-in"]}>
               <div>プロフィール</div>
-              <div className={mypage["menu-icon"]}><AiOutlineUser /></div>
+              <div className={mypage["menu-icon"]}><FcVoicePresentation /></div>
             </Tab>
           </TabList>
 

--- a/frontend/app/src/components/model/comment/Comment.js
+++ b/frontend/app/src/components/model/comment/Comment.js
@@ -1,5 +1,4 @@
 import { useComment } from "../../../hooks/useComment";
-import ReactLoading from "react-loading";
 import commentCss from '../../../css/model/comment/comment.module.css';
 import CommentDelete from "./ui/CommentDelete";
 import { useUser } from "../../../hooks/useUser";
@@ -8,7 +7,7 @@ import { AuthContext } from "../../../providers/AuthGuard";
 import { useContext } from "react";
 import { useGeneralComment } from "../../../hooks/useGeneralComment";
 import moment from 'moment';
-import { BsCalendar3 } from "react-icons/bs";
+import { FcCalendar } from "react-icons/fc";
 
 const Comment = ({scene_post_id}) => {
   const { useGetComment } = useComment();
@@ -20,9 +19,9 @@ const Comment = ({scene_post_id}) => {
   const { data: generalComments, isLoading: generalLoading } = useGetGeneralComment(scene_post_id);
   const { data: user, isLoading: userLoading } = useGetUser();
 
-  if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
-  if(generalLoading) return <ReactLoading type="spin" color='blue' className='loading' />
-  if(userLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  if(isLoading) return <></>
+  if(generalLoading) return <></>
+  if(userLoading) return <></>
 
   return (
     <>
@@ -40,7 +39,7 @@ const Comment = ({scene_post_id}) => {
                     <CommentDelete comment_id={comment.id} scene_post_id={scene_post_id} />
                   </div>
                 )}
-                <div className={commentCss["create-at"]}><span className={commentCss["detail-text"]}><span className={commentCss["bs-calender-3"]}><BsCalendar3 /></span>{ moment(comment.attributes.created_at).format('YYYY年MM月DD日HH:mm') }</span></div>
+                <div className={commentCss["create-at"]}><span className={commentCss["detail-text"]}><span className={commentCss["react-icon"]}><FcCalendar /></span>{ moment(comment.attributes.created_at).format('YYYY年MM月DD日HH:mm') }</span></div>
               </div>
             </div>
           ))}
@@ -54,7 +53,7 @@ const Comment = ({scene_post_id}) => {
               <div className={commentCss["detail-area"]}>
                 <div>{ general_comment.attributes.body }</div>
               </div>
-              <div className={commentCss["create-at"]}><span className={commentCss["detail-text"]}><span className={commentCss["bs-calender-3"]}><BsCalendar3 /></span>{ moment(general_comment.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+              <div className={commentCss["create-at"]}><span className={commentCss["detail-text"]}><span className={commentCss["react-icon"]}><FcCalendar /></span>{ moment(general_comment.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
             </div>
           </div>
           ))}

--- a/frontend/app/src/components/model/general/GeneralComic.js
+++ b/frontend/app/src/components/model/general/GeneralComic.js
@@ -5,7 +5,7 @@ import noimage from "../../../image/default.png";
 import generalComic from "../../../css/model/general/generalComic.module.css";
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
-import { BsBookFill, BsJournalBookmarkFill, BsSearch, BsCalendar3 } from "react-icons/bs";
+import { FcReading, FcFile, FcCalendar, FcMms, FcSearch } from "react-icons/fc";
 import { useMemo, useState } from "react";
 import moment from 'moment';
 
@@ -69,7 +69,7 @@ const GeneralComic = () => {
           <span className={subMenu.home}>
             <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
           </span>
-          <span>/ 投稿一覧</span>
+          <span>/ 漫画一覧</span>
         </div>
       </div>
       <div className={generalComic.count}>【投稿数】 {comics.data.length}件</div>
@@ -77,7 +77,7 @@ const GeneralComic = () => {
         <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え </button>
       </div>
       <div className={generalComic.search}>
-        <span className={generalComic["bs-search"]}><BsSearch /></span>
+        <span className={generalComic["fc-search"]}><FcSearch /></span>
         <input
           className={generalComic["search-text"]}
           value={searchText}
@@ -95,20 +95,20 @@ const GeneralComic = () => {
               <div className={generalComic.list}>
                 <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />{ comic.attributes.comicUserName }</div>
                 <div className={generalComic["detail-area"]}>
-                  <p className={generalComic.detail}><span className={generalComic["bs-book-fill"]}><BsBookFill /></span>【漫画名】</p>
+                  <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcReading /></span>漫画名</p>
                   <div>{ comic.attributes.title }</div>
                 </div>
                 <div className={generalComic["detail-area"]}>
-                  <p className={generalComic.detail}><span className={generalComic["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【ジャンル】</p>
+                  <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcFile /></span>ジャンル</p>
                   <div>{ comic.attributes.genre }</div>
                 </div>
                 <div className={generalComic["detail-area-link"]}>
-                  <Link to={`/general_scene_post/${comic.attributes.title}/${comic.id}`} className={generalComic["link-show"]} >シーンを見る</Link>
+                  <Link to={`/general_scene_post/${comic.attributes.title}/${comic.id}`} className={generalComic["link-show"]} ><span className={generalComic["react-icon"]}><FcMms /></span>シーンを見る</Link>
                 </div>
               </div>
               <div className={generalComic["outer-image"]}>
                 <div className={generalComic["detail-area-image"]}>
-                  <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["bs-calender-3"]}><BsCalendar3 /></span>{ moment(comic.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+                  <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["react-icon"]}><FcCalendar /></span>{ moment(comic.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
                   <img className={generalComic.image} src={ comic.attributes.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
                 </div>
               </div>

--- a/frontend/app/src/components/model/general/GeneralScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralScenePost.js
@@ -1,13 +1,13 @@
 import { useParams, Link } from "react-router-dom";
 import { useGeneralScenePost } from "../../../hooks/useGeneralScenePost";
 import ReactLoading from "react-loading";
-import generalScenePostCss from '../../../css/model/general/generalScenePostCss.module.css';
+import generalScenePost from '../../../css/model/general/generalScenePost.module.css';
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
 import GeneralScenePostCard from "./ui/GeneralScenePostCard";
 import { AuthContext } from "../../../providers/AuthGuard";
 import { useContext, useMemo, useState } from "react";
-import { BsSearch } from "react-icons/bs";
+import { FcSearch } from "react-icons/fc";
 
 const GeneralScenePost = () => {
   const { comic_id, comic_title } = useParams();
@@ -123,25 +123,25 @@ const GeneralScenePost = () => {
           </span>
         </div>
       </div>
-      <div className={generalScenePostCss.count}>【投稿数】 {scene_posts.data.length}件</div>
+      <div className={generalScenePost.count}>【投稿数】 {scene_posts.data.length}件</div>
       {isAuthenticated ? (
         <>
-          <div className={generalScenePostCss.sort}>
+          <div className={generalScenePost.sort}>
             <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え </button>
           </div>
-          <div className={generalScenePostCss.search}>
-            <span className={generalScenePostCss["bs-search"]}><BsSearch /></span>
+          <div className={generalScenePost.search}>
+            <span className={generalScenePost["fc-search"]}><FcSearch /></span>
             <input
-              className={generalScenePostCss["search-text"]}
+              className={generalScenePost["search-text"]}
               value={searchText}
               onChange={(e) => setSearchText(e.target.value)}
               placeholder={'サブタイトルを検索'}
             />
           </div>
           { data.length === 0 && (
-            <div className={generalScenePostCss["detail-result"]}>検索結果がありません</div>
+            <div className={generalScenePost["detail-result"]}>検索結果がありません</div>
           ) }
-          <div className={generalScenePostCss["main-content"]}>
+          <div className={generalScenePost["main-content"]}>
             {sortedData.map((scene_post, index) => (
               <GeneralScenePostCard
                 key={index}
@@ -160,22 +160,22 @@ const GeneralScenePost = () => {
         </>
       ) : (
         <>
-          <div className={generalScenePostCss.sort}>
+          <div className={generalScenePost.sort}>
             <button className={generalSort.key === 'id' ? generalSort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleGeneralSort('id')}>並び替え </button>
           </div>
-          <div className={generalScenePostCss.search}>
-            <span className={generalScenePostCss["bs-search"]}><BsSearch /></span>
+          <div className={generalScenePost.search}>
+            <span className={generalScenePost["fc-search"]}><FcSearch /></span>
             <input
-              className={generalScenePostCss["search-text"]}
+              className={generalScenePost["search-text"]}
               value={searchGeneralText}
               onChange={(e) => setSearchGeneralText(e.target.value)}
               placeholder={'サブタイトルを検索'}
             />
           </div>
           { generalData.length === 0 && (
-            <div className={generalScenePostCss["detail-result"]}>検索結果がありません</div>
+            <div className={generalScenePost["detail-result"]}>検索結果がありません</div>
           ) }
-          <div className={generalScenePostCss["main-content"]}>
+          <div className={generalScenePost["main-content"]}>
             {sortedGeneralData.map((scene_post, index) => (
               <GeneralScenePostCard
                 key={index}

--- a/frontend/app/src/components/model/general/GeneralScenePostShow.js
+++ b/frontend/app/src/components/model/general/GeneralScenePostShow.js
@@ -4,7 +4,7 @@ import ReactLoading from "react-loading";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
-import { BsBookFill, BsFillReplyFill, BsFillPencilFill, BsCalendar3, BsNewspaper, BsFillJournalBookmarkFill, BsReceipt, BsFillChatRightDotsFill } from "react-icons/bs";
+import { FcReading, FcFilm, FcKindle, FcSms, FcCalendar, FcContacts, FcNews, FcUpLeft } from "react-icons/fc";
 import noimage from "../../../image/default.png";
 import Comment from "../comment/Comment";
 import { AuthContext } from "../../../providers/AuthGuard";
@@ -20,7 +20,6 @@ const GeneralScenePostShow = () => {
   const { data: scene_post, isLoading} = useShowGeneralScenePost(scene_post_id);
 
   if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
-  console.log(scene_post)
 
   return (
     <div className={subMenu.wrapper}>
@@ -43,42 +42,42 @@ const GeneralScenePostShow = () => {
             <img className={scenePostShow.image} src={ scene_post.data.attributes.sceneImage.url } alt='画像' onError={(e) => e.target.src = noimage} />
           </div>
           <div className={scenePostShow.article}>
-            <p className={scenePostShow["comic-title"]}><span className={scenePostShow["bs-book-fill"]}><BsBookFill /></span>{ scene_post.data.attributes.scenePostComicTitle }</p>
+            <p className={scenePostShow["comic-title"]}><span className={scenePostShow["react-icon"]}><FcReading /></span>{ scene_post.data.attributes.scenePostComicTitle }</p>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-pencil-fill"]}><BsFillPencilFill /></span>【シーンのサブタイトル】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcFilm /></span>シーンのサブタイトル</p>
               <div>{ scene_post.data.attributes.subTitle }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-receipt"]}><BsReceipt /></span>【シーンの内容】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcNews /></span>シーンの内容</p>
               <div>{ scene_post.data.attributes.sceneTitle }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-journal-bookmark-fill"]}><BsFillJournalBookmarkFill /></span>【シーンの話数】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcContacts /></span>シーンの話数</p>
               <div>{ scene_post.data.attributes.sceneNumber }話</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-calender-3"]}><BsCalendar3 /></span>【そのシーンを見た日付】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcCalendar /></span>そのシーンを見た日付</p>
               <div>{ scene_post.data.attributes.sceneDate }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-newspaper"]}><BsNewspaper /></span>【シーンの詳細・感想】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcKindle /></span>シーンの詳細・感想</p>
               <div>{ scene_post.data.attributes.sceneContent }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <button onClick={() => navigate(`/general_scene_post/${scene_post.data.attributes.scenePostComicTitle}/${scene_post.data.attributes.comicId}`)} className={scenePostShow.back}><span className={scenePostShow["bs-fill-replay-fill"]}><BsFillReplyFill /></span>シーン一覧へ戻る</button>
+              <button onClick={() => navigate(`/general_scene_post/${scene_post.data.attributes.scenePostComicTitle}/${scene_post.data.attributes.comicId}`)} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>シーン一覧へ戻る</button>
             </div>
-            <div className={scenePostShow["create-at"]}><span className={scenePostShow["detail-text"]}><span className={scenePostShow["bs-calender-3"]}><BsCalendar3 /></span>{ moment(scene_post.data.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+            <div className={scenePostShow["create-at"]}><span className={scenePostShow["detail-text"]}><span className={scenePostShow["react-icon"]}><FcCalendar /></span>{ moment(scene_post.data.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
             {isAuthenticated ? (
               <div className={scenePostShow["detail-area-comment"]}>
-                <Link className={scenePostShow.comment} to={`/general_scene_post/${scene_post.data.attributes.scenePostComicTitle}/${scene_post_id}/comment`}>コメントする</Link>
+                <Link className={scenePostShow.comment} to={`/general_scene_post/${scene_post.data.attributes.scenePostComicTitle}/${scene_post_id}/comment`}><span className={scenePostShow["react-icon"]}><FcSms /></span>コメントする</Link>
               </div>
             ) : (
               <div className={scenePostShow["detail-area-comment"]}>
-                <button className={scenePostShow.comment} onClick={() => { loginWithRedirect(); }}>コメントする</button>
+                <button className={scenePostShow.comment} onClick={() => { loginWithRedirect(); }}><span className={scenePostShow["react-icon"]}><FcSms /></span>コメントする</button>
               </div>
             )}
             <div className={scenePostShow["detail-area-comment"]}>
-              <div className={scenePostShow["detail-comment"]}><span className={scenePostShow["bs-fill-chat-right-dots-fill"]}><BsFillChatRightDotsFill /></span>【コメント一覧】</div>
+              <div className={scenePostShow["detail-comment"]}><span className={scenePostShow["react-icon"]}><FcSms /></span>コメント一覧</div>
               <Comment scene_post_id={scene_post_id} />
             </div>
           </div>

--- a/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
@@ -1,8 +1,7 @@
 import { useContext, useState } from "react";
 import generalScenePost from '../../../../css/model/general/generalScenePost.module.css';
 import noimage from "../../../../image/default.png";
-import { FcFilm, FcContacts, FcCalendar, FcMms, FcSms } from "react-icons/fc";
-import { BsBookmark } from "react-icons/bs";
+import { FcFilm, FcContacts, FcCalendar, FcMms, FcSms, FcLikePlaceholder } from "react-icons/fc";
 import UnFavoriteButton from "../../../ui/UnFavoriteButton";
 import FavoriteButton from "../../../ui/FavoriteButton";
 import { Link } from "react-router-dom";
@@ -53,11 +52,10 @@ const GeneralScenePostCard = ({
             <button
               className={generalScenePost.favorite}
               type='submit'
-              value={`お気に入り`}
               onClick={() => {
                 loginWithRedirect();
               }}
-            ><BsBookmark /></button>
+            ><FcLikePlaceholder /></button>
           )}
           <div className={generalScenePost["detail-area"]}>
             <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcFilm /></span>サブタイトル</p>

--- a/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
@@ -9,6 +9,7 @@ import { AuthContext } from "../../../../providers/AuthGuard";
 import { useGeneralComment } from "../../../../hooks/useGeneralComment";
 import ReactLoading from "react-loading";
 import moment from 'moment';
+import { useFavorite } from "../../../../hooks/useFavorite";
 
 const GeneralScenePostCard = ({
   scenePostId,
@@ -25,38 +26,44 @@ const GeneralScenePostCard = ({
   const { isAuthenticated, loginWithRedirect } = useContext(AuthContext);
 
   const { useGetGeneralComment } = useGeneralComment();
+  const { useGetFavorites_count } = useFavorite();
 
   const { data: generalComments, isLoading } = useGetGeneralComment(scenePostId);
+  const { data: favorites, favoritesLoading } = useGetFavorites_count(scenePostId);
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  if(favoritesLoading) return <></>
 
   return (
     <div className={generalScenePost.content}>
       <div className={generalScenePost["innner-content"]}>
         <div className={generalScenePost.list}>
           <div className={generalScenePost["user-name"]}><img className={generalScenePost["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />{ scenePostUserName }</div>
-          {isAuthenticated ? (
-            <>
-              {favoriteState ? (
-                <UnFavoriteButton
-                  id={scenePostId}
-                  changeFavorite={setFavoriteState}
-                />
-              ) : (
-                <FavoriteButton
-                  id={scenePostId}
-                  changeFavorite={setFavoriteState}
-                />
-              )}
-            </>
-          ) : (
-            <button
-              className={generalScenePost.favorite}
-              type='submit'
-              onClick={() => {
-                loginWithRedirect();
-              }}
-            ><FcLikePlaceholder /></button>
-          )}
+          <div className={generalScenePost["outer-favorite"]}>
+            {isAuthenticated ? (
+              <>
+                {favoriteState ? (
+                  <UnFavoriteButton
+                    id={scenePostId}
+                    changeFavorite={setFavoriteState}
+                  />
+                ) : (
+                  <FavoriteButton
+                    id={scenePostId}
+                    changeFavorite={setFavoriteState}
+                  />
+                )}
+              </>
+            ) : (
+              <button
+                className={generalScenePost.favorite}
+                type='submit'
+                onClick={() => {
+                  loginWithRedirect();
+                }}
+              ><FcLikePlaceholder /></button>
+            )}
+            <div className={generalScenePost["favorite-count"]}>{ favorites?.length }</div>
+          </div>
           <div className={generalScenePost["detail-area"]}>
             <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcFilm /></span>サブタイトル</p>
             <div>{ scenePostSubTitle }</div>

--- a/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
@@ -1,7 +1,8 @@
 import { useContext, useState } from "react";
-import generalScenePostCss from '../../../../css/model/general/generalScenePostCss.module.css';
+import generalScenePost from '../../../../css/model/general/generalScenePost.module.css';
 import noimage from "../../../../image/default.png";
-import { BsBookFill, BsJournalBookmarkFill, BsBookmark, BsCalendar3, BsFillChatRightDotsFill } from "react-icons/bs";
+import { FcFilm, FcContacts, FcCalendar, FcMms, FcSms } from "react-icons/fc";
+import { BsBookmark } from "react-icons/bs";
 import UnFavoriteButton from "../../../ui/UnFavoriteButton";
 import FavoriteButton from "../../../ui/FavoriteButton";
 import { Link } from "react-router-dom";
@@ -30,10 +31,10 @@ const GeneralScenePostCard = ({
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
   return (
-    <div className={generalScenePostCss.content}>
-      <div className={generalScenePostCss["innner-content"]}>
-        <div className={generalScenePostCss.list}>
-          <div className={generalScenePostCss["user-name"]}><img className={generalScenePostCss["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />{ scenePostUserName }</div>
+    <div className={generalScenePost.content}>
+      <div className={generalScenePost["innner-content"]}>
+        <div className={generalScenePost.list}>
+          <div className={generalScenePost["user-name"]}><img className={generalScenePost["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />{ scenePostUserName }</div>
           {isAuthenticated ? (
             <>
               {favoriteState ? (
@@ -50,7 +51,7 @@ const GeneralScenePostCard = ({
             </>
           ) : (
             <button
-              className={generalScenePostCss.favorite}
+              className={generalScenePost.favorite}
               type='submit'
               value={`お気に入り`}
               onClick={() => {
@@ -58,25 +59,25 @@ const GeneralScenePostCard = ({
               }}
             ><BsBookmark /></button>
           )}
-          <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-book-fill"]}><BsBookFill /></span>【サブタイトル】</p>
+          <div className={generalScenePost["detail-area"]}>
+            <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcFilm /></span>サブタイトル</p>
             <div>{ scenePostSubTitle }</div>
           </div>
-          <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの話数】</p>
+          <div className={generalScenePost["detail-area"]}>
+            <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcContacts /></span>シーンの話数</p>
             <div>{ scenePostNumber }話</div>
           </div>
-          <div className={generalScenePostCss["detail-area-link"]}>
-            <Link to={`/general_scene_post/${comicTitle}/general_scene_post_show/${scenePostId}`} className={generalScenePostCss["link-show"]} >シーンを見る</Link>
+          <div className={generalScenePost["detail-area-link"]}>
+            <Link to={`/general_scene_post/${comicTitle}/general_scene_post_show/${scenePostId}`} className={generalScenePost["link-show"]} ><span className={generalScenePost["react-icon"]}><FcMms /></span>シーンを見る</Link>
           </div>
         </div>
-        <div className={generalScenePostCss["outer-image"]}>
-          <div className={generalScenePostCss["detail-area-image"]}>
-            <div className={generalScenePostCss["create-at"]}><span className={generalScenePostCss["detail-text"]}><span className={generalScenePostCss["bs-calender-3"]}><BsCalendar3 /></span>{ moment(scenePostCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
-            <img className={generalScenePostCss.image} src={ scenePostImage } alt='画像' onError={(e) => e.target.src = noimage} />
-            <div className={generalScenePostCss['detail-area-count']}>
-              <div className={generalScenePostCss['detail-area-list']}>
-                <div><span className={generalScenePostCss["bs-fill-chat-right-dots-fill"]}><BsFillChatRightDotsFill /></span>コメント&nbsp;{ generalComments.data.length }件</div>
+        <div className={generalScenePost["outer-image"]}>
+          <div className={generalScenePost["detail-area-image"]}>
+            <div className={generalScenePost["create-at"]}><span className={generalScenePost["detail-text"]}><span className={generalScenePost["react-icon"]}><FcCalendar /></span>{ moment(scenePostCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+            <img className={generalScenePost.image} src={ scenePostImage } alt='画像' onError={(e) => e.target.src = noimage} />
+            <div className={generalScenePost['detail-area-count']}>
+              <div className={generalScenePost['detail-area-list']}>
+                <div><span className={generalScenePost["react-icon"]}><FcSms /></span>コメント&nbsp;{ generalComments.data.length }件</div>
               </div>
             </div>
           </div>

--- a/frontend/app/src/components/model/mypage/ComicEdit.js
+++ b/frontend/app/src/components/model/mypage/ComicEdit.js
@@ -11,8 +11,7 @@ import { ComicDeleteButton } from "../../ui/Parts";
 import axios from "axios";
 import { AuthContext } from "../../../providers/AuthGuard";
 import { useContext } from "react";
-import { BsFillReplyFill } from "react-icons/bs";
-import { FiSend } from "react-icons/fi";
+import { FcReading, FcHighPriority, FcFile, FcPicture, FcFeedback, FcUpLeft } from "react-icons/fc";
 
 const ComicEdit = () => {
   const navigate = useNavigate();
@@ -80,22 +79,23 @@ const ComicEdit = () => {
       <div className={subMenu.content}>
         <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>漫画のタイトル</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcReading /></span>漫画のタイトル</div>
             { errors.title &&
-              <div className={form.errors}>【！漫画のタイトルが空欄です】</div> 
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>漫画のタイトルが空欄です</div> 
             }
             <input
               className={form["form-input"]}
               defaultValue={ comics.title }
+              placeholder={"漫画のタイトルを入力してください"}
               {...register('title', {
                 required: true
               })}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>漫画のジャンル</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcFile /></span>漫画のジャンル</div>
             { errors.genre &&
-              <div className={form.errors}>【！漫画のジャンルを選択してください】</div> 
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>漫画のジャンルを選択してください</div> 
             }
             <select
               className={form["form-input"]}
@@ -110,7 +110,7 @@ const ComicEdit = () => {
             </select>
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>漫画の画像</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcPicture /></span>漫画の画像</div>
             <input
               className={form["form-input-image"]}
               type="file"
@@ -119,13 +119,13 @@ const ComicEdit = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <button className={form["form-submit"]} type="submit"><span className={form["fi-send"]}><FiSend /></span>この内容で登録する</button>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
           </div>
           <div className={form["form-text-delete"]}>
             <ComicDeleteButton handleDeleteComic={handleDeleteComic} />
           </div>
           <div className={form["form-text-back"]}>
-            <button onClick={() => navigate('/mypage')} className={scenePostShow.back}><span className={scenePostShow["bs-fill-replay-fill"]}><BsFillReplyFill /></span>マイページへ戻る</button>
+            <button onClick={() => navigate('/mypage')} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>マイページへ戻る</button>
           </div>
         </form>
       </div>

--- a/frontend/app/src/components/model/mypage/ComicNew.js
+++ b/frontend/app/src/components/model/mypage/ComicNew.js
@@ -5,7 +5,7 @@ import comicNewGenreJson from "../../../json/comicNewGenre.json";
 import { useContext } from "react";
 import axios from "axios";
 import { AuthContext } from "../../../providers/AuthGuard";
-import { FiSend } from "react-icons/fi";
+import { FcFeedback, FcReading, FcFile, FcHighPriority, FcPicture } from "react-icons/fc";
 
 const ComicNew = () => {
   const navigate = useNavigate();
@@ -38,9 +38,9 @@ const ComicNew = () => {
     <div className={form.wrapper}>
       <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
         <div className={form["form-text"]}>
-          <div className={form["form-label"]}>漫画のタイトル</div>
+          <div className={form["form-label"]}><span className={form["react-icon"]}><FcReading /></span>漫画のタイトル</div>
           { errors.title &&
-            <div className={form.errors}>【！漫画のタイトルが空欄です】</div> 
+            <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>漫画のタイトルが空欄です</div> 
           }
           <input
             className={form["form-input"]}
@@ -52,9 +52,9 @@ const ComicNew = () => {
           />
         </div>
         <div className={form["form-text"]}>
-          <div className={form["form-label"]}>漫画のジャンル</div>
+          <div className={form["form-label"]}><span className={form["react-icon"]}><FcFile /></span>漫画のジャンル</div>
           { errors.genre &&
-            <div className={form.errors}>【！漫画のジャンルを選択してください】</div> 
+            <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>漫画のジャンルを選択してください</div> 
           }
           <select
             className={form["form-input"]}
@@ -70,7 +70,7 @@ const ComicNew = () => {
           </select>
         </div>
         <div className={form["form-text"]}>
-          <div className={form["form-label"]}>漫画の画像</div>
+          <div className={form["form-label"]}><span className={form["react-icon"]}><FcPicture /></span>漫画の画像</div>
           <input
             className={form["form-input-image"]}
             type="file"
@@ -79,7 +79,7 @@ const ComicNew = () => {
           />
         </div>
         <div className={form["form-text-submit"]}>
-          <button className={form["form-submit"]} type="submit"><span className={form["fi-send"]}><FiSend /></span>この内容で登録する</button>
+          <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
         </div>
       </form>
     </div>

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { useComic } from '../../../hooks/useComic';
 import ReactLoading from "react-loading";
 import noimage from "../../../image/default.png";
-import { BsBookFill, BsJournalBookmarkFill, BsSearch, BsCalendar3 } from "react-icons/bs";
+import { FcReading, FcFile, FcCalendar, FcMms, FcSearch, FcEditImage } from "react-icons/fc";
 import moment from 'moment';
 
 const ComicPost = () => {
@@ -65,7 +65,7 @@ const ComicPost = () => {
       <div className={comicPost.count}>【投稿数】 {comics.length}件</div>
       <button className={sort.key === 'updated_at' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('updated_at')}>並び替え </button>
       <div className={comicPost.search}>
-        <span className={comicPost["bs-search"]}><BsSearch /></span>
+        <span className={comicPost["bs-search"]}><FcSearch /></span>
         <input
           className={comicPost["search-text"]}
           value={searchText}
@@ -85,19 +85,19 @@ const ComicPost = () => {
               </div>
               <div className={comicPost.list}>
                 <div className={comicPost["detail-area"]}>
-                  <p className={comicPost.detail}><span className={comicPost["bs-book-fill"]}><BsBookFill /></span>【漫画名】</p>
+                  <p className={comicPost.detail}><span className={comicPost["react-icon"]}><FcReading /></span>漫画名</p>
                   <div>{ comic.title }</div>
                 </div>
                 <div className={comicPost["detail-area"]}>
-                  <p className={comicPost.detail}><span className={comicPost["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【ジャンル】</p>
+                  <p className={comicPost.detail}><span className={comicPost["react-icon"]}><FcFile /></span>ジャンル</p>
                   <div>{ comic.genre }</div>
                 </div>
               </div>
               <div className={comicPost["link-list"]}>
-                <Link to={`/comic/${comic.id}/${comic.title}`} className={comicPost["link-show"]} >シーンを見る/追加する</Link>
-                <Link to={`/comic/${comic.id}/${comic.title}/comic_edit`} className={comicPost["link-edit"]} >編集する</Link>
+                <Link to={`/comic/${comic.id}/${comic.title}`} className={comicPost["link-show"]} ><span className={comicPost["react-icon"]}><FcMms /></span>シーンを見る/追加する</Link>
+                <Link to={`/comic/${comic.id}/${comic.title}/comic_edit`} className={comicPost["link-edit"]} ><span className={comicPost["react-icon"]}><FcEditImage /></span>編集する</Link>
               </div>
-              <div className={comicPost["create-at"]}><span className={comicPost["detail-text"]}><span className={comicPost["bs-calender-3"]}><BsCalendar3 /></span>{ moment(comic.created_at).format('YYYY年MM月DD日HH:mm') }</span></div>
+              <div className={comicPost["create-at"]}><span className={comicPost["detail-text"]}><span className={comicPost["react-icon"]}><FcCalendar /></span>{ moment(comic.created_at).format('YYYY年MM月DD日HH:mm') }</span></div>
             </div>
           </div>
         ))}

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -65,7 +65,7 @@ const ComicPost = () => {
       <div className={comicPost.count}>【投稿数】 {comics.length}件</div>
       <button className={sort.key === 'updated_at' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('updated_at')}>並び替え </button>
       <div className={comicPost.search}>
-        <span className={comicPost["bs-search"]}><FcSearch /></span>
+        <span className={comicPost["fc-search"]}><FcSearch /></span>
         <input
           className={comicPost["search-text"]}
           value={searchText}

--- a/frontend/app/src/components/model/mypage/Profile.js
+++ b/frontend/app/src/components/model/mypage/Profile.js
@@ -6,6 +6,7 @@ import noimage from "../../../image/default.png";
 import { useComic } from '../../../hooks/useComic';
 import { useFavorite } from '../../../hooks/useFavorite';
 import profile from '../../../css/model/profile.module.css';
+import { FcPortraitMode, FcGraduationCap, FcImageFile, FcEditImage, FcLike, FcReading } from "react-icons/fc";
 
 const Profile = () => {
   const { useGetUser } = useUser();
@@ -18,44 +19,44 @@ const Profile = () => {
   const regExp = /(https?:\/\/\S+)/g;
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
-  if(favoriteLoading) return <ReactLoading type="spin" color='blue' className='loading' />
-  if(comicLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  if(favoriteLoading) return <></>
+  if(comicLoading) return <></>
 
   return (
     <div className={profile.wrapper}>
       <div className={profile.section}>
         <div className={profile.content}>
           <div className={profile['detail-area']}>
-            <h3 className={profile.detail}>プロフィール</h3>
+            <h3 className={profile["detail-profile"]}>【プロフィール】</h3>
           </div>
           <div className={profile['detail-area']}>
-            <p className={profile.detail}>【ユーザー名】</p>
+            <p className={profile.detail}><span className={profile["react-icon"]}><FcPortraitMode /></span>ユーザー名</p>
             <div>{ user.name }</div>
           </div>
           <div className={profile['outer-image']}>
             <img className={profile.image} src={ user.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
           </div>
           <div className={profile['detail-area']}>
-            <p className={profile.detail}>【自己紹介】</p>
+            <p className={profile.detail}><span className={profile["react-icon"]}><FcGraduationCap /></span>自己紹介</p>
             <div>{ user.introduction }</div>
           </div>
           <div className={profile['detail-area-last']}>
-            <p className={profile.detail}>【webサイトリンク】</p>
+            <p className={profile.detail}><span className={profile["react-icon"]}><FcImageFile /></span>webサイトリンク</p>
             {reactStringReplace(user.url, regExp, (match, i) => (
               <a className={profile.a} key={i} href={match}>{match}</a>
             ))}
           </div>
           <div className={profile['detail-area']}>
-            <Link to={`/my-profile/${user.id}`} className={profile.button}>プロフィールを編集する</Link>
+            <Link to={`/my-profile/${user.id}`} className={profile.button}><span className={profile["react-icon"]}><FcEditImage /></span>プロフィールを編集する</Link>
           </div>
           <div className={profile['detail-area-count']}>
             <div className={profile.list}>
-              <p className={profile['detail-list']}>【投稿数】</p>
-              <div>{ comics.length}</div>
+              <p className={profile['detail-list']}><span className={profile["react-icon"]}><FcReading /></span>投稿数</p>
+              <div>{ comics.length}件</div>
             </div>
             <div className={profile.list}>
-              <p className={profile['detail-list']}>【お気に入り数】</p>
-              <div>{ favorites.data.length }</div>
+              <p className={profile['detail-list']}><span className={profile["react-icon"]}><FcLike /></span>お気に入り数</p>
+              <div>{ favorites.data.length }件</div>
             </div>
           </div>
         </div>

--- a/frontend/app/src/components/model/mypage/Profile.js
+++ b/frontend/app/src/components/model/mypage/Profile.js
@@ -6,21 +6,23 @@ import noimage from "../../../image/default.png";
 import { useComic } from '../../../hooks/useComic';
 import { useFavorite } from '../../../hooks/useFavorite';
 import profile from '../../../css/model/profile.module.css';
-import { FcPortraitMode, FcGraduationCap, FcImageFile, FcEditImage, FcLike, FcReading } from "react-icons/fc";
+import { FcPortraitMode, FcGraduationCap, FcImageFile, FcEditImage, FcLike, FcReading, FcFilm } from "react-icons/fc";
 
 const Profile = () => {
   const { useGetUser } = useUser();
-  const { useGetComic } = useComic();
+  const { useGetComic, useGetScenePostCount } = useComic();
   const { useGetFavorite } = useFavorite();
 
   const { data: favorites, isLoading: favoriteLoading } = useGetFavorite();
   const { data: comics, isLoading: comicLoading } = useGetComic();
+  const { data: scenePostCounts, isLoading: scenePostCountsLoading } = useGetScenePostCount();
   const { data: user, isLoading } = useGetUser();
   const regExp = /(https?:\/\/\S+)/g;
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
   if(favoriteLoading) return <></>
   if(comicLoading) return <></>
+  if(scenePostCountsLoading) return <></>
 
   return (
     <div className={profile.wrapper}>
@@ -51,8 +53,12 @@ const Profile = () => {
           </div>
           <div className={profile['detail-area-count']}>
             <div className={profile.list}>
-              <p className={profile['detail-list']}><span className={profile["react-icon"]}><FcReading /></span>投稿数</p>
+              <p className={profile['detail-list']}><span className={profile["react-icon"]}><FcReading /></span>漫画数</p>
               <div>{ comics.length}件</div>
+            </div>
+            <div className={profile.list}>
+              <p className={profile['detail-list']}><span className={profile["react-icon"]}><FcFilm /></span>シーン数</p>
+              <div>{ scenePostCounts.length }件</div>
             </div>
             <div className={profile.list}>
               <p className={profile['detail-list']}><span className={profile["react-icon"]}><FcLike /></span>お気に入り数</p>

--- a/frontend/app/src/components/model/mypage/favorite/Favorite.js
+++ b/frontend/app/src/components/model/mypage/favorite/Favorite.js
@@ -1,7 +1,7 @@
 import { useFavorite } from "../../../../hooks/useFavorite";
 import ReactLoading from "react-loading";
 import favorite from '../../../../css/model/mypage/favorite.module.css';
-import { BsSearch } from "react-icons/bs";
+import { FcSearch } from "react-icons/fc";
 import { useState } from "react";
 import FavoriteCard from "./ui/FavoriteCard";
 
@@ -23,12 +23,13 @@ const Favorite = () => {
   }
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  console.log(data)
 
   return (
     <div className={favorite.wrapper}>
       <div className={favorite.count}>【投稿数】 {favorites.data.length}件</div>
       <div className={favorite.search}>
-        <span className={favorite["bs-search"]}><BsSearch /></span>
+      <span className={favorite["fc-search"]}><FcSearch /></span>
         <input
           className={favorite["search-text"]}
           value={searchText}
@@ -49,6 +50,7 @@ const Favorite = () => {
             favoriteSubTitle={favorite.attributes.sub_title}
             favoriteNumber={favorite.attributes.scene_number}
             favoriteImage={favorite.attributes.scene_image.url}
+            favoriteCreatedAt={favorite.attributes.created_at}
           />
         ))}
       </div>

--- a/frontend/app/src/components/model/mypage/favorite/ui/FavoriteCard.js
+++ b/frontend/app/src/components/model/mypage/favorite/ui/FavoriteCard.js
@@ -1,9 +1,10 @@
 import { Link } from "react-router-dom";
 import noimage from "../../../../../image/default.png";
 import generalScenePostCss from '../../../../../css/model/general/generalScenePostCss.module.css';
-import { BsBookFill, BsJournalBookmarkFill, BsFillChatRightDotsFill } from "react-icons/bs";
+import { FcFilm, FcContacts, FcSms, FcMms, FcCalendar } from "react-icons/fc";
 import { useGeneralComment } from "../../../../../hooks/useGeneralComment";
 import ReactLoading from "react-loading";
+import moment from 'moment';
 
 const FavoriteCard = ({
   Id,
@@ -11,7 +12,8 @@ const FavoriteCard = ({
   favoriteUserName,
   favoriteSubTitle,
   favoriteNumber,
-  favoriteImage
+  favoriteImage,
+  favoriteCreatedAt
 }) => {
   const { useGetGeneralComment } = useGeneralComment();
 
@@ -24,23 +26,24 @@ const FavoriteCard = ({
         <div className={generalScenePostCss.list}>
           <div className={generalScenePostCss["user-name"]}><img className={generalScenePostCss["user-image"]} src={ favoriteUserImage } alt='画像' onError={(e) => e.target.src = noimage} />{ favoriteUserName }</div>
           <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-book-fill"]}><BsBookFill /></span>【サブタイトル】</p>
+            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["react-icon"]}><FcFilm /></span>サブタイトル</p>
             <div>{ favoriteSubTitle }</div>
           </div>
           <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【シーンの話数】</p>
+            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["react-icon"]}><FcContacts /></span>シーンの話数</p>
             <div>{ favoriteNumber }話</div>
           </div>
           <div className={generalScenePostCss["detail-area-link"]}>
-            <Link to={`/general_scene_post/general_scene_post_show/${Id}`} className={generalScenePostCss["link-show"]} >シーンを見る</Link>
+            <Link to={`/general_scene_post/general_scene_post_show/${Id}`} className={generalScenePostCss["link-show"]}><span className={generalScenePostCss["react-icon"]}><FcMms /></span>シーンを見る</Link>
           </div>
         </div>
-        <div className={generalScenePostCss["outer-image"]}>
+        <div className={generalScenePostCss["favorite-outer-image"]}>
           <div className={generalScenePostCss["detail-area-image"]}>
-            <img className={generalScenePostCss.image} src={ favoriteImage } alt='画像' onError={(e) => e.target.src = noimage} />
+          <div className={generalScenePostCss["create-at"]}><span className={generalScenePostCss["detail-text"]}><span className={generalScenePostCss["react-icon"]}><FcCalendar /></span>{ moment(favoriteCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+            <img className={generalScenePostCss["favorite-image"]} src={ favoriteImage } alt='画像' onError={(e) => e.target.src = noimage} />
             <div className={generalScenePostCss['detail-area-count']}>
               <div className={generalScenePostCss['detail-area-list']}>
-                <div><span className={generalScenePostCss["bs-fill-chat-right-dots-fill"]}><BsFillChatRightDotsFill /></span>コメント&nbsp;{ generalComments.data.length }件</div>
+                <div><span className={generalScenePostCss["react-icon"]}><FcSms /></span>コメント&nbsp;{ generalComments.data.length }件</div>
               </div>
             </div>
           </div>

--- a/frontend/app/src/components/model/mypage/favorite/ui/FavoriteCard.js
+++ b/frontend/app/src/components/model/mypage/favorite/ui/FavoriteCard.js
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import noimage from "../../../../../image/default.png";
-import generalScenePostCss from '../../../../../css/model/general/generalScenePostCss.module.css';
+import generalScenePost from '../../../../../css/model/general/generalScenePost.module.css';
 import { FcFilm, FcContacts, FcSms, FcMms, FcCalendar } from "react-icons/fc";
 import { useGeneralComment } from "../../../../../hooks/useGeneralComment";
 import ReactLoading from "react-loading";
@@ -21,29 +21,29 @@ const FavoriteCard = ({
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
 
   return (
-    <div className={generalScenePostCss.content}>
-      <div className={generalScenePostCss["innner-content"]}>
-        <div className={generalScenePostCss.list}>
-          <div className={generalScenePostCss["user-name"]}><img className={generalScenePostCss["user-image"]} src={ favoriteUserImage } alt='画像' onError={(e) => e.target.src = noimage} />{ favoriteUserName }</div>
-          <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["react-icon"]}><FcFilm /></span>サブタイトル</p>
+    <div className={generalScenePost.content}>
+      <div className={generalScenePost["innner-content"]}>
+        <div className={generalScenePost.list}>
+          <div className={generalScenePost["user-name"]}><img className={generalScenePost["user-image"]} src={ favoriteUserImage } alt='画像' onError={(e) => e.target.src = noimage} />{ favoriteUserName }</div>
+          <div className={generalScenePost["detail-area"]}>
+            <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcFilm /></span>サブタイトル</p>
             <div>{ favoriteSubTitle }</div>
           </div>
-          <div className={generalScenePostCss["detail-area"]}>
-            <p className={generalScenePostCss.detail}><span className={generalScenePostCss["react-icon"]}><FcContacts /></span>シーンの話数</p>
+          <div className={generalScenePost["detail-area"]}>
+            <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcContacts /></span>シーンの話数</p>
             <div>{ favoriteNumber }話</div>
           </div>
-          <div className={generalScenePostCss["detail-area-link"]}>
-            <Link to={`/general_scene_post/general_scene_post_show/${Id}`} className={generalScenePostCss["link-show"]}><span className={generalScenePostCss["react-icon"]}><FcMms /></span>シーンを見る</Link>
+          <div className={generalScenePost["detail-area-link"]}>
+            <Link to={`/general_scene_post/general_scene_post_show/${Id}`} className={generalScenePost["link-show"]}><span className={generalScenePost["react-icon"]}><FcMms /></span>シーンを見る</Link>
           </div>
         </div>
-        <div className={generalScenePostCss["favorite-outer-image"]}>
-          <div className={generalScenePostCss["detail-area-image"]}>
-          <div className={generalScenePostCss["create-at"]}><span className={generalScenePostCss["detail-text"]}><span className={generalScenePostCss["react-icon"]}><FcCalendar /></span>{ moment(favoriteCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
-            <img className={generalScenePostCss["favorite-image"]} src={ favoriteImage } alt='画像' onError={(e) => e.target.src = noimage} />
-            <div className={generalScenePostCss['detail-area-count']}>
-              <div className={generalScenePostCss['detail-area-list']}>
-                <div><span className={generalScenePostCss["react-icon"]}><FcSms /></span>コメント&nbsp;{ generalComments.data.length }件</div>
+        <div className={generalScenePost["favorite-outer-image"]}>
+          <div className={generalScenePost["detail-area-image"]}>
+          <div className={generalScenePost["create-at"]}><span className={generalScenePost["detail-text"]}><span className={generalScenePost["react-icon"]}><FcCalendar /></span>{ moment(favoriteCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+            <img className={generalScenePost["favorite-image"]} src={ favoriteImage } alt='画像' onError={(e) => e.target.src = noimage} />
+            <div className={generalScenePost['detail-area-count']}>
+              <div className={generalScenePost['detail-area-list']}>
+                <div><span className={generalScenePost["react-icon"]}><FcSms /></span>コメント&nbsp;{ generalComments.data.length }件</div>
               </div>
             </div>
           </div>

--- a/frontend/app/src/components/model/profile/MyProfile.js
+++ b/frontend/app/src/components/model/profile/MyProfile.js
@@ -5,11 +5,12 @@ import PasswordChange from './PasswordChange';
 import ProfileEdit from './ProfileEdit';
 import subMenu from "../../../css/ui/subMenu.module.css";
 import mypage from "../../../css/mypage.module.css";
-import { AiFillHome, AiOutlineUser, AiFillUnlock } from "react-icons/ai";
+import { AiFillHome } from "react-icons/ai";
+import { FcVoicePresentation, FcUnlock } from "react-icons/fc";
 
 const MyProfile = () => {
   const [tabIndex, setTabIndex] = useState(0);
-  const color = { color: 'red' }
+  const color = { background: '#ffc0cb' }
 
   return (
     <div className={mypage.wrapper}>
@@ -29,11 +30,11 @@ const MyProfile = () => {
           <TabList className={mypage["menu-list"]}>
             <Tab style={ tabIndex === 0 ? color : null } className={mypage["menu-list-in"]}>
               <div>プロフィール情報</div>
-              <div className={mypage["menu-icon"]}><AiOutlineUser /></div>
+              <div className={mypage["menu-icon"]}><FcVoicePresentation /></div>
             </Tab>
             <Tab style={ tabIndex === 1 ? color : null } className={mypage["menu-list-in"]}>
               <div>パスワード変更</div>
-              <div className={mypage["menu-icon"]}><AiFillUnlock /></div>
+              <div className={mypage["menu-icon"]}><FcUnlock /></div>
             </Tab>
           </TabList>
 

--- a/frontend/app/src/components/model/profile/PasswordChange.js
+++ b/frontend/app/src/components/model/profile/PasswordChange.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useForm } from "react-hook-form";
 import form from "../../../css/ui/form.module.css";
-import { FiSend } from "react-icons/fi";
+import { FcFeedback, FcHighPriority } from "react-icons/fc";
 
 const PasswordChange = () => {
   const onSubmit = async (data) => {
@@ -26,7 +26,7 @@ const PasswordChange = () => {
         <div className={form["form-text"]}>
           <div className={form["form-label"]}>パスワード変更のリンクを受信するメールアドレス</div>
           { errors.email &&
-            <div className={form.errors}>【！メールアドレスを入力してください】</div> 
+            <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>メールアドレスを入力してください</div> 
           }
           <input
             className={form["form-input"]}
@@ -50,8 +50,8 @@ const PasswordChange = () => {
             required: true
           })}
         />
-        <div className={form["form-text"]}>
-            <button className={form["form-submit"]} type="submit"><span className={form["fi-send"]}><FiSend /></span>送信する</button>
+        <div className={form["form-text-submit"]}>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>送信する</button>
         </div>
       </form>
     </div>

--- a/frontend/app/src/components/model/profile/ProfileEdit.js
+++ b/frontend/app/src/components/model/profile/ProfileEdit.js
@@ -4,8 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useUser } from "../../../hooks/useUser";
 import { AuthContext } from "../../../providers/AuthGuard";
 import form from "../../../css/ui/form.module.css";
-import { BsFillReplyFill } from "react-icons/bs";
-import { FiSend } from "react-icons/fi";
+import { FcPortraitMode, FcGraduationCap, FcImageFile, FcFeedback, FcButtingIn, FcUpLeft, FcHighPriority } from "react-icons/fc";
 import axios from "axios";
 import ReactLoading from "react-loading";
 import subMenu from "../../../css/ui/subMenu.module.css";
@@ -51,36 +50,39 @@ const ProfileEdit = () => {
       <div className={subMenu.content}>
         <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>ユーザー名</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcPortraitMode /></span>ユーザー名</div>
             { errors.name &&
-              <div className={form.errors}>【！ユーザー名がありません】</div> 
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>ユーザー名がありません</div> 
             }
             <input
               className={form["form-input"]}
               defaultValue={ user.name }
+              placeholder={"ユーザー名を入力してください"}
               {...register('name', {
                 required: true
               })}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>自己紹介</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcGraduationCap /></span>自己紹介</div>
             <input
               className={form["form-input"]}
               defaultValue={ user.introduction }
+              placeholder={"自己紹介を入力してください"}
               {...register('introduction')}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>リンク</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcImageFile /></span>リンク</div>
             <input
               className={form["form-input"]}
               defaultValue={ user.url }
+              placeholder={"WEBのリンクなどを入力してください"}
               {...register('url')}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>ユーザーアイコン</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcButtingIn /></span>ユーザーアイコン</div>
             <input
               className={form["form-input-image"]}
               type="file"
@@ -89,10 +91,10 @@ const ProfileEdit = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <button className={form["form-submit"]} type="submit"><span className={form["fi-send"]}><FiSend /></span>この内容で登録する</button>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
           </div>
           <div className={form["form-text-back"]}>
-            <button onClick={() => navigate('/mypage')} className={scenePostShow.back}><span className={scenePostShow["bs-fill-replay-fill"]}><BsFillReplyFill /></span>マイページへ戻る</button>
+            <button onClick={() => navigate('/mypage')} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>マイページへ戻る</button>
           </div>
         </form>
       </div>

--- a/frontend/app/src/components/model/scene_post/ScenePost.js
+++ b/frontend/app/src/components/model/scene_post/ScenePost.js
@@ -3,7 +3,7 @@ import ReactLoading from "react-loading";
 import { Link, useParams } from 'react-router-dom';
 import scenePost from '../../../css/model/scene_post/scenePost.module.css';
 import { AiFillHome } from "react-icons/ai";
-import { BsSearch } from "react-icons/bs";
+import { FcSearch, FcAddImage } from "react-icons/fc";
 import { useMemo, useState } from 'react';
 import ScenePostCard from './ui/ScenePostCard';
 
@@ -82,7 +82,7 @@ const ScenePost = () => {
         <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え </button>
       </div>
       <div className={scenePost.search}>
-        <span className={scenePost["bs-search"]}><BsSearch /></span>
+        <span className={scenePost["fc-search"]}><FcSearch /></span>
         <input
           className={scenePost["search-text"]}
           value={searchText}
@@ -91,7 +91,7 @@ const ScenePost = () => {
         />
       </div>
       <button className={scenePost.link}>
-        <Link to={`/comic/${comic_id}/${comic_title}/scene_post_new`}>新規のシーンを投稿する</Link>
+        <Link to={`/comic/${comic_id}/${comic_title}/scene_post_new`}><span className={scenePost["react-icon"]}><FcAddImage /></span>新規のシーンを投稿する</Link>
       </button>
       { data.length === 0 && (
         <div className={scenePost["detail-result"]}>検索結果がありません</div>

--- a/frontend/app/src/components/model/scene_post/ScenePostEdit.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostEdit.js
@@ -6,8 +6,7 @@ import { useForm } from "react-hook-form";
 import form from "../../../css/ui/form.module.css";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import { AiFillHome } from "react-icons/ai";
-import { BsFillReplyFill } from "react-icons/bs";
-import { FiSend } from "react-icons/fi";
+import { FcFilm, FcHighPriority, FcCalendar, FcKindle, FcPicture, FcFeedback, FcUpLeft, FcContacts, FcNews } from "react-icons/fc";
 import { ScenePostDeleteButton } from "../../ui/Parts";
 import { AuthContext } from "../../../providers/AuthGuard";
 import { useContext } from "react";
@@ -93,22 +92,37 @@ const ScenePostEdit = () => {
       <div className={subMenu.content}>
         <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>シーンのタイトル</div>
-            { errors.scene_title &&
-              <div className={form.errors}>【！シーンのタイトルが空欄です】</div> 
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcFilm /></span>サブタイトル</div>
+            { errors.sub_title &&
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>サブタイトルが空欄です</div> 
             }
             <input
               className={form["form-input"]}
               defaultValue={ scene_post.scene_title }
+              placeholder="サブタイトルを入力してください"
+              {...register('sub_title', {
+                required: true
+              })}
+            />
+          </div>
+          <div className={form["form-text"]}>
+            <div className={form["form-label"]}><span className={scenePostShow["react-icon"]}><FcNews /></span>シーンの内容</div>
+            { errors.scene_title &&
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>好きなシーン名が空欄です</div> 
+            }
+            <input
+              className={form["form-input"]}
+              defaultValue={ scene_post.scene_title }
+              placeholder="好きなシーンの内容を入力してください"
               {...register('scene_title', {
                 required: true
               })}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>漫画の話数</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcContacts /></span>漫画の話数</div>
             { errors.scene_number &&
-              <div className={form.errors}>【！漫画の話数を選択してください】</div> 
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>漫画の話数を選択してください</div> 
             }
             <select
               className={form["form-input"]}
@@ -123,31 +137,27 @@ const ScenePostEdit = () => {
             </select>
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>好きなシーンを見た日付</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcCalendar /></span>シーンを見た日付</div>
             <input
               type='date'
               defaultValue={ scene_post.scene_date }
               className={form["form-input"]}
-              {...register('scene_date', {
-                required: true
-              })}
+              {...register('scene_date')}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>シーンの内容</div>
-            { errors.scene_content &&
-              <div className={form.errors}>【！シーンの内容が空欄です】</div> 
-            }
-            <input
+            <div className={form["form-label"]}><span className={scenePostShow["react-icon"]}><FcKindle /></span>シーンの詳細・感想</div>
+            <textarea
+              rows='10'
+              cols='60'
               className={form["form-input"]}
+              placeholder="好きなシーンの内容を入力してください"
               defaultValue={ scene_post.scene_content }
-              {...register('scene_content', {
-                required: true
-              })}
+              {...register('scene_content')}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>シーンの画像</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcPicture /></span>シーンの画像</div>
             <input
               className={form["form-input-image"]}
               type="file"
@@ -156,13 +166,13 @@ const ScenePostEdit = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <button className={form["form-submit"]} type="submit"><span className={form["fi-send"]}><FiSend /></span>この内容で登録する</button>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
           </div>
           <div className={form["form-text-delete"]}>
             <ScenePostDeleteButton handleDeleteScenePost={handleDeleteScenePost} />
           </div>
           <div className={form["form-text-back"]}>
-            <button onClick={() => navigate(`/comic/${comic_id}/${comic_title}`)} className={scenePostShow.back}><span className={scenePostShow["bs-fill-replay-fill"]}><BsFillReplyFill /></span>シーン一覧へ戻る</button>
+            <button onClick={() => navigate(`/comic/${comic_id}/${comic_title}`)} className={scenePostShow.back}><span className={form["react-icon"]}><FcUpLeft /></span>シーン一覧へ戻る</button>
           </div>
         </form>
       </div>

--- a/frontend/app/src/components/model/scene_post/ScenePostNew.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostNew.js
@@ -7,8 +7,7 @@ import { AiFillHome } from "react-icons/ai";
 import { AuthContext } from "../../../providers/AuthGuard";
 import { useContext } from "react";
 import axios from "axios";
-import { BsFillReplyFill } from "react-icons/bs";
-import { FiSend } from "react-icons/fi";
+import { FcFilm, FcHighPriority, FcContacts, FcCalendar, FcKindle, FcPicture, FcFeedback, FcUpLeft, FcNews } from "react-icons/fc";
 
 const ScenePostNew = () => {
   const { comic_id, comic_title } = useParams();
@@ -72,9 +71,9 @@ const ScenePostNew = () => {
       <div className={subMenu.content}>
         <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>サブタイトル</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcFilm /></span>サブタイトル</div>
             { errors.sub_title &&
-              <div className={form.errors}>【！サブタイトルが空欄です】</div> 
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>サブタイトルが空欄です</div> 
             }
             <input
               className={form["form-input"]}
@@ -85,9 +84,9 @@ const ScenePostNew = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>好きなシーン名</div>
+            <div className={form["form-label"]}><span className={scenePostShow["react-icon"]}><FcNews /></span>シーンの内容</div>
             { errors.scene_title &&
-              <div className={form.errors}>【！好きなシーン名が空欄です】</div> 
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>好きなシーン名が空欄です</div> 
             }
             <input
               className={form["form-input"]}
@@ -98,9 +97,9 @@ const ScenePostNew = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>漫画の話数</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcContacts /></span>漫画の話数</div>
             { errors.scene_number &&
-              <div className={form.errors}>【！漫画の話数を選択してください】</div> 
+              <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>漫画の話数を選択してください</div> 
             }
             <select
               className={form["form-input"]}
@@ -115,33 +114,26 @@ const ScenePostNew = () => {
             </select>
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>好きなシーンを見た日付</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcCalendar /></span>シーンを見た日付</div>
             <input
               type='date'
               className={form["form-input"]}
               placeholder="好きなシーン名を入力してください"
-              {...register('scene_date', {
-                required: true
-              })}
+              {...register('scene_date')}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>好きなシーンの内容</div>
-            { errors.scene_title &&
-              <div className={form.errors}>【！好きなシーンの内容が空欄です】</div> 
-            }
+            <div className={form["form-label"]}><span className={scenePostShow["react-icon"]}><FcKindle /></span>シーンの詳細・感想</div>
             <textarea
               rows='10'
               cols='60'
               className={form["form-input"]}
-              placeholder="好きなシーン内容を入力してください"
-              {...register('scene_content', {
-                required: true
-              })}
+              placeholder="好きなシーンの内容を入力してください"
+              {...register('scene_content')}
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}>シーンの画像</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcPicture /></span>シーンの画像</div>
             <input
               className={form["form-input-image"]}
               type="file"
@@ -150,10 +142,10 @@ const ScenePostNew = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <button className={form["form-submit"]} type="submit"><span className={form["fi-send"]}><FiSend /></span>この内容で登録する</button>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
           </div>
           <div className={form["form-text-back"]}>
-            <button onClick={() => navigate(-1)} className={scenePostShow.back}><span className={scenePostShow["bs-fill-replay-fill"]}><BsFillReplyFill /></span>{ comic_title }のシーン一覧に戻る</button>
+            <button onClick={() => navigate(-1)} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>{ comic_title }のシーン一覧に戻る</button>
           </div>
         </form>
       </div>

--- a/frontend/app/src/components/model/scene_post/ScenePostShow.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostShow.js
@@ -3,7 +3,7 @@ import { useScenePost } from "../../../hooks/useScenePost";
 import ReactLoading from "react-loading";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import { AiFillHome } from "react-icons/ai";
-import { BsBookFill, BsFillReplyFill, BsFillPencilFill, BsCalendar3, BsNewspaper, BsFillJournalBookmarkFill, BsReceipt, BsFillChatRightDotsFill } from "react-icons/bs";
+import { FcReading, FcFilm, FcKindle, FcSms, FcCalendar, FcContacts, FcNews, FcUpLeft } from "react-icons/fc";
 import noimage from "../../../image/default.png";
 import moment from 'moment';
 import Comment from "../comment/Comment";
@@ -38,33 +38,33 @@ const ScenePostShow = () => {
             <img className={scenePostShow.image} src={ scene_post.scene_image.url } alt='画像' onError={(e) => e.target.src = noimage} />
           </div>
           <div className={scenePostShow.article}>
-            <p className={scenePostShow["comic-title"]}><span className={scenePostShow["bs-book-fill"]}><BsBookFill /></span>{ comic_title }</p>
+            <p className={scenePostShow["comic-title"]}><span className={scenePostShow["react-icon"]}><FcReading /></span>{ comic_title }</p>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-pencil-fill"]}><BsFillPencilFill /></span>【シーンのサブタイトル】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcFilm /></span>シーンのサブタイトル</p>
               <div>{ scene_post.sub_title }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-receipt"]}><BsReceipt /></span>【シーンの内容】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcNews /></span>シーンの内容</p>
               <div>{ scene_post.scene_title }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-fill-journal-bookmark-fill"]}><BsFillJournalBookmarkFill /></span>【シーンの話数】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcContacts /></span>シーンの話数</p>
               <div>{ scene_post.scene_number }話</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-calender-3"]}><BsCalendar3 /></span>【シーンを見た日付】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcCalendar /></span>シーンを見た日付</p>
               <div>{ scene_post.scene_date }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <p className={scenePostShow.detail}><span className={scenePostShow["bs-newspaper"]}><BsNewspaper /></span>【シーンの詳細・感想】</p>
+              <p className={scenePostShow.detail}><span className={scenePostShow["react-icon"]}><FcKindle /></span>シーンの詳細・感想</p>
               <div>{ scene_post.scene_content }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
-              <button onClick={() => navigate(-1)} className={scenePostShow.back}><span className={scenePostShow["bs-fill-replay-fill"]}><BsFillReplyFill /></span>シーン一覧へ戻る</button>
+              <button onClick={() => navigate(-1)} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>シーン一覧へ戻る</button>
             </div>
-            <div className={scenePostShow["create-at"]}><span className={scenePostShow["detail-text"]}><span className={scenePostShow["bs-calender-3"]}><BsCalendar3 /></span>{ moment(scene_post.created_at).format('YYYY年MM月DD日HH:mm') }</span></div>
+            <div className={scenePostShow["create-at"]}><span className={scenePostShow["detail-text"]}><span className={scenePostShow["react-icon"]}><FcCalendar /></span>{ moment(scene_post.created_at).format('YYYY年MM月DD日HH:mm') }</span></div>
             <div className={scenePostShow["detail-area-comment"]}>
-              <div className={scenePostShow["detail-comment"]}><span className={scenePostShow["bs-fill-chat-right-dots-fill"]}><BsFillChatRightDotsFill /></span>【コメント一覧】</div>
+              <div className={scenePostShow["detail-comment"]}><span className={scenePostShow["react-icon"]}><FcSms /></span>コメント一覧</div>
               <Comment scene_post_id={scene_post_id} />
             </div>
           </div>

--- a/frontend/app/src/components/model/scene_post/ScenePostShow.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostShow.js
@@ -2,6 +2,7 @@ import { useParams, Link, useNavigate } from "react-router-dom";
 import { useScenePost } from "../../../hooks/useScenePost";
 import ReactLoading from "react-loading";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
+import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
 import { FcReading, FcFilm, FcKindle, FcSms, FcCalendar, FcContacts, FcNews, FcUpLeft } from "react-icons/fc";
 import noimage from "../../../image/default.png";
@@ -18,16 +19,16 @@ const ScenePostShow = () => {
   if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
 
   return (
-    <div className={scenePostShow.wrapper}>
-      <div className={scenePostShow["top-list"]}>
-        <div className={scenePostShow.title}>
-          <span className={scenePostShow.home}>
-            <Link to='/' className={scenePostShow["home-link"]}><span className={scenePostShow["react-icons"]}><AiFillHome /></span>ホーム</Link>
+    <div className={subMenu.wrapper}>
+      <div className={subMenu["top-list"]}>
+        <div className={subMenu.title}>
+          <span className={subMenu.home}>
+            <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
           </span>
           <span>
-            <Link to='/mypage' className={scenePostShow["home-link"]}><span>/ マイページ</span></Link>
+            <Link to='/mypage' className={subMenu["home-link"]}><span>/ マイページ</span></Link>
           </span>
-          <span className={scenePostShow["scene-title"]}>
+          <span className={subMenu["scene-title"]}>
             / { scene_post.sub_title }の詳細画面
           </span>
         </div>

--- a/frontend/app/src/components/model/scene_post/ui/ScenePostCard.js
+++ b/frontend/app/src/components/model/scene_post/ui/ScenePostCard.js
@@ -1,10 +1,9 @@
 import { Link } from "react-router-dom";
 import scenePost from '../../../../css/model/scene_post/scenePost.module.css';
 import moment from 'moment';
-import { BsBookFill, BsJournalBookmarkFill, BsCalendar3, BsFillChatRightDotsFill } from "react-icons/bs";
 import noimage from "../../../../image/default.png";
-import ReactLoading from "react-loading";
 import { useGeneralComment } from "../../../../hooks/useGeneralComment";
+import { FcCalendar, FcMms, FcFilm, FcContacts, FcSms, FcEditImage } from "react-icons/fc";
 
 const ScenePostCard = ({
   scenePostId,
@@ -19,7 +18,7 @@ const ScenePostCard = ({
 
   const { data: generalComments, isLoading } = useGetGeneralComment(scenePostId);
 
-  if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  if(isLoading) return <></>
 
   return (
     <div className={scenePost.content}>
@@ -29,22 +28,22 @@ const ScenePostCard = ({
         </div>
         <div className={scenePost.list}>
           <div className={scenePost["detail-area"]}>
-              <p className={scenePost.detail}><span className={scenePost["bs-book-fill"]}><BsBookFill /></span>【サブタイトル】</p>
+              <p className={scenePost.detail}><span className={scenePost["react-icon"]}><FcFilm /></span>サブタイトル</p>
               <div>{ scenePostSubTitle}</div>
           </div>
           <div className={scenePost["detail-area"]}>
-            <p className={scenePost.detail}><span className={scenePost["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【話数】</p>
+            <p className={scenePost.detail}><span className={scenePost["react-icon"]}><FcContacts /></span>話数</p>
             <div>{ scenePostNumber }話</div>
           </div>
         </div>
         <div className={scenePost["link-list"]}>
-          <Link to={`/scene_post/${comicTitle}/${scenePostId}`} className={scenePost["link-show"]} >シーンを見る</Link>
-          <Link to={`/scene_post/${comicId}/${comicTitle}/${scenePostId}/scene_post_edit`} className={scenePost["link-edit"]} >編集する</Link>
+          <Link to={`/scene_post/${comicTitle}/${scenePostId}`} className={scenePost["link-show"]} ><span className={scenePost["react-icon"]}><FcMms /></span>シーンを見る</Link>
+          <Link to={`/scene_post/${comicId}/${comicTitle}/${scenePostId}/scene_post_edit`} className={scenePost["link-edit"]}><span className={scenePost["react-icon"]}><FcEditImage /></span>編集する</Link>
         </div>
-        <div className={scenePost["create-at"]}><span className={scenePost["detail-text"]}><span className={scenePost["bs-calender-3"]}><BsCalendar3 /></span>{ moment(scenePostCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+        <div className={scenePost["create-at"]}><span className={scenePost["detail-text"]}><span className={scenePost["react-icon"]}><FcCalendar /></span>{ moment(scenePostCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
         <div className={scenePost['detail-area-count']}>
           <div className={scenePost['detail-area-list']}>
-            <div><span className={scenePost["bs-fill-chat-right-dots-fill"]}><BsFillChatRightDotsFill /></span>コメント&nbsp;{ generalComments.data.length }件</div>
+            <div><span className={scenePost["react-icon"]}><FcSms /></span>コメント&nbsp;{ generalComments.data.length }件</div>
           </div>
         </div>
       </div>

--- a/frontend/app/src/components/model/user/GeneralUser.js
+++ b/frontend/app/src/components/model/user/GeneralUser.js
@@ -1,0 +1,60 @@
+import { useGeneralUser } from "../../../hooks/useGeneralUser";
+import ReactLoading from "react-loading";
+import { Link } from "react-router-dom";
+import subMenu from '../../../css/ui/subMenu.module.css';
+import { AiFillHome } from "react-icons/ai";
+import generalUser from "../../../css/model/user/generalUser.module.css";
+import profile from '../../../css/model/profile.module.css';
+import reactStringReplace from "react-string-replace";
+
+const GeneralUser = () => {
+  const { useGetGeneralUser } = useGeneralUser();
+  const { data: users, isLoading } = useGetGeneralUser();
+  const regExp = /(https?:\/\/\S+)/g;
+
+  if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  console.log(users)
+
+  return (
+    <div className={subMenu.wrapper}>
+      <div className={subMenu["top-list"]}>
+        <div className={subMenu.title}>
+          <span className={subMenu.home}>
+            <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
+          </span>
+          <span>/ ユーザー一覧</span>
+        </div>
+      </div>
+      <div className={generalUser["main-content"]}>
+        {users.map((user) => (
+          <div key={user.id} className={profile.section}>
+            <div className={profile.content}>
+              <div className={profile['detail-area']}>
+                <h3 className={profile.detail}>プロフィール</h3>
+              </div>
+              <div className={profile['detail-area']}>
+                <p className={profile.detail}>【ユーザー名】</p>
+                <div>{ user.name }</div>
+              </div>
+              <div className={profile['outer-image']}>
+                <img className={profile.image} src={ user.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
+              </div>
+              <div className={profile['detail-area']}>
+                <p className={profile.detail}>【自己紹介】</p>
+                <div>{ user.introduction }</div>
+              </div>
+              <div className={profile['detail-area-last']}>
+                <p className={profile.detail}>【webサイトリンク】</p>
+                {reactStringReplace(user.url, regExp, (match, i) => (
+                  <a className={profile.a} key={i} href={match}>{match}</a>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GeneralUser;

--- a/frontend/app/src/components/model/user/GeneralUser.js
+++ b/frontend/app/src/components/model/user/GeneralUser.js
@@ -11,7 +11,6 @@ const GeneralUser = () => {
   const { data: users, isLoading } = useGetGeneralUser();
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
-  console.log(users)
 
   return (
     <div className={subMenu.wrapper}>

--- a/frontend/app/src/components/model/user/GeneralUser.js
+++ b/frontend/app/src/components/model/user/GeneralUser.js
@@ -4,13 +4,11 @@ import { Link } from "react-router-dom";
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
 import generalUser from "../../../css/model/user/generalUser.module.css";
-import profile from '../../../css/model/profile.module.css';
-import reactStringReplace from "react-string-replace";
+import GeneralUserCard from "./ui/GeneralUserCard";
 
 const GeneralUser = () => {
   const { useGetGeneralUser } = useGeneralUser();
   const { data: users, isLoading } = useGetGeneralUser();
-  const regExp = /(https?:\/\/\S+)/g;
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
   console.log(users)
@@ -26,31 +24,15 @@ const GeneralUser = () => {
         </div>
       </div>
       <div className={generalUser["main-content"]}>
-        {users.map((user) => (
-          <div key={user.id} className={profile.section}>
-            <div className={profile.content}>
-              <div className={profile['detail-area']}>
-                <h3 className={profile.detail}>プロフィール</h3>
-              </div>
-              <div className={profile['detail-area']}>
-                <p className={profile.detail}>【ユーザー名】</p>
-                <div>{ user.name }</div>
-              </div>
-              <div className={profile['outer-image']}>
-                <img className={profile.image} src={ user.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
-              </div>
-              <div className={profile['detail-area']}>
-                <p className={profile.detail}>【自己紹介】</p>
-                <div>{ user.introduction }</div>
-              </div>
-              <div className={profile['detail-area-last']}>
-                <p className={profile.detail}>【webサイトリンク】</p>
-                {reactStringReplace(user.url, regExp, (match, i) => (
-                  <a className={profile.a} key={i} href={match}>{match}</a>
-                ))}
-              </div>
-            </div>
-          </div>
+        {users.map((user, index) => (
+          <GeneralUserCard
+            key={index}
+            userId={user.id}
+            userName={user.name}
+            userImage={user.image.url}
+            userIntroduction={user.introduction}
+            userUrl={user.url}
+          />
         ))}
       </div>
     </div>

--- a/frontend/app/src/components/model/user/GeneralUserComic.js
+++ b/frontend/app/src/components/model/user/GeneralUserComic.js
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router-dom";
 import { AiFillHome } from "react-icons/ai";
 import generalComic from "../../../css/model/general/generalComic.module.css";
 import subMenu from '../../../css/ui/subMenu.module.css';
-import { BsBookFill, BsJournalBookmarkFill, BsSearch, BsCalendar3 } from "react-icons/bs";
+import { FcReading, FcFile, FcCalendar, FcMms } from "react-icons/fc";
 import moment from 'moment';
 import noimage from "../../../image/default.png";
 
@@ -38,20 +38,20 @@ const GeneralUserComic = () => {
               <div className={generalComic.list}>
                 <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ user.image.url } alt='画像' onError={(e) => e.target.src = noimage} />{ user.name }</div>
                 <div className={generalComic["detail-area"]}>
-                  <p className={generalComic.detail}><span className={generalComic["bs-book-fill"]}><BsBookFill /></span>【漫画名】</p>
+                  <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcReading /></span>漫画名</p>
                   <div>{ comic.title }</div>
                 </div>
                 <div className={generalComic["detail-area"]}>
-                  <p className={generalComic.detail}><span className={generalComic["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【ジャンル】</p>
+                  <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcFile /></span>ジャンル</p>
                   <div>{ comic.genre }</div>
                 </div>
                 <div className={generalComic["detail-area-link"]}>
-                  <Link to={`/general_scene_post/${comic.title}/${comic.id}`} className={generalComic["link-show"]} >シーンを見る</Link>
+                  <Link to={`/general_scene_post/${comic.title}/${comic.id}`} className={generalComic["link-show"]} ><span className={generalComic["react-icon"]}><FcMms /></span>シーンを見る</Link>
                 </div>
               </div>
               <div className={generalComic["outer-image"]}>
                 <div className={generalComic["detail-area-image"]}>
-                  <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["bs-calender-3"]}><BsCalendar3 /></span>{ moment(comic.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+                  <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["react-icon"]}><FcCalendar /></span>{ moment(comic.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
                   <img className={generalComic.image} src={ comic.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
                 </div>
               </div>

--- a/frontend/app/src/components/model/user/GeneralUserComic.js
+++ b/frontend/app/src/components/model/user/GeneralUserComic.js
@@ -10,10 +10,12 @@ import noimage from "../../../image/default.png";
 
 const GeneralUserComic = () => {
   const { user_id } = useParams();
-  const { useGetGeneralUserComic } = useGeneralUser();
+  const { useGetGeneralUserComic, useShowGeneralUser } = useGeneralUser();
 
   const { data: comics, isLoading } = useGetGeneralUserComic(user_id);
+  const { data: user, isLoading: userLoading } = useShowGeneralUser(user_id);
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  if(userLoading) return <></>
 
   return (
     <div className={subMenu.wrapper}>
@@ -22,15 +24,19 @@ const GeneralUserComic = () => {
           <span className={subMenu.home}>
             <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
           </span>
-          <span>/ 漫画一覧</span>
+          <span className={subMenu.home}>
+            <Link to='/users' className={subMenu["home-link"]}>/&nbsp;ユーザー一覧</Link>
+          </span>
+          <span>/&nbsp;{user.name}の漫画一覧</span>
         </div>
       </div>
+      <div className={generalComic.count}>【投稿数】 {comics.length}件</div>
       <div className={generalComic["main-content"]}>
         {comics.map((comic) => (
           <div key={comic.id} className={generalComic.content}>
             <div className={generalComic["innner-content"]}>
               <div className={generalComic.list}>
-                {/* <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />{ comic.attributes.comicUserName }</div> */}
+                <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ user.image.url } alt='画像' onError={(e) => e.target.src = noimage} />{ user.name }</div>
                 <div className={generalComic["detail-area"]}>
                   <p className={generalComic.detail}><span className={generalComic["bs-book-fill"]}><BsBookFill /></span>【漫画名】</p>
                   <div>{ comic.title }</div>

--- a/frontend/app/src/components/model/user/GeneralUserComic.js
+++ b/frontend/app/src/components/model/user/GeneralUserComic.js
@@ -1,0 +1,60 @@
+import { useGeneralUser } from "../../../hooks/useGeneralUser";
+import ReactLoading from "react-loading";
+import { Link, useParams } from "react-router-dom";
+import { AiFillHome } from "react-icons/ai";
+import generalComic from "../../../css/model/general/generalComic.module.css";
+import subMenu from '../../../css/ui/subMenu.module.css';
+import { BsBookFill, BsJournalBookmarkFill, BsSearch, BsCalendar3 } from "react-icons/bs";
+import moment from 'moment';
+import noimage from "../../../image/default.png";
+
+const GeneralUserComic = () => {
+  const { user_id } = useParams();
+  const { useGetGeneralUserComic } = useGeneralUser();
+
+  const { data: comics, isLoading } = useGetGeneralUserComic(user_id);
+  if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+
+  return (
+    <div className={subMenu.wrapper}>
+      <div className={subMenu["top-list"]}>
+        <div className={subMenu.title}>
+          <span className={subMenu.home}>
+            <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
+          </span>
+          <span>/ 漫画一覧</span>
+        </div>
+      </div>
+      <div className={generalComic["main-content"]}>
+        {comics.map((comic) => (
+          <div key={comic.id} className={generalComic.content}>
+            <div className={generalComic["innner-content"]}>
+              <div className={generalComic.list}>
+                {/* <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />{ comic.attributes.comicUserName }</div> */}
+                <div className={generalComic["detail-area"]}>
+                  <p className={generalComic.detail}><span className={generalComic["bs-book-fill"]}><BsBookFill /></span>【漫画名】</p>
+                  <div>{ comic.title }</div>
+                </div>
+                <div className={generalComic["detail-area"]}>
+                  <p className={generalComic.detail}><span className={generalComic["bs-journal-book-mark-fill"]}><BsJournalBookmarkFill /></span>【ジャンル】</p>
+                  <div>{ comic.genre }</div>
+                </div>
+                <div className={generalComic["detail-area-link"]}>
+                  <Link to={`/general_scene_post/${comic.title}/${comic.id}`} className={generalComic["link-show"]} >シーンを見る</Link>
+                </div>
+              </div>
+              <div className={generalComic["outer-image"]}>
+                <div className={generalComic["detail-area-image"]}>
+                  <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["bs-calender-3"]}><BsCalendar3 /></span>{ moment(comic.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+                  <img className={generalComic.image} src={ comic.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GeneralUserComic;

--- a/frontend/app/src/components/model/user/ui/GeneralUserCard.js
+++ b/frontend/app/src/components/model/user/ui/GeneralUserCard.js
@@ -13,10 +13,12 @@ const GeneralUserCard = ({
   userUrl
 }) => {
   const regExp = /(https?:\/\/\S+)/g;
-  const { useGetGeneralUserComic } = useGeneralUser();
+  const { useGetGeneralUserComic, useGetGeneralScenePostCount } = useGeneralUser();
 
   const { data: comic, isLoading } = useGetGeneralUserComic(userId);
+  const { data: scenePostCount, isLoading: scenePostCountLoading } = useGetGeneralScenePostCount(userId);
   if(isLoading) return <></>
+  if(scenePostCountLoading) return <></>
 
   return (
     <div className={generalUser.content}>
@@ -40,7 +42,7 @@ const GeneralUserCard = ({
             </div>
             <div className={generalUser["detail-area-list"]}>
               <p className={generalUser['detail-list']}><span className={generalUser["react-icon"]}><FcFilm /></span>シーン数</p>
-              <div>数字</div>
+              <div>{ scenePostCount.length }</div>
             </div>
           </div>
           <div className={generalUser["detail-area-link"]}>

--- a/frontend/app/src/components/model/user/ui/GeneralUserCard.js
+++ b/frontend/app/src/components/model/user/ui/GeneralUserCard.js
@@ -2,7 +2,8 @@ import generalUser from "../../../../css/model/user/generalUser.module.css";
 import reactStringReplace from "react-string-replace";
 import noimage from "../../../../image/default.png";
 import { useGeneralUser } from '../../../../hooks/useGeneralUser';
-import { FcVoicePresentation, FcDocument, FcFilm, FcReading, FcPodiumWithSpeaker } from "react-icons/fc";
+import { FcVoicePresentation, FcDocument, FcFilm, FcReading, FcPodiumWithSpeaker, FcMms } from "react-icons/fc";
+import { Link } from "react-router-dom";
 
 const GeneralUserCard = ({
   userId,
@@ -41,6 +42,9 @@ const GeneralUserCard = ({
               <p className={generalUser['detail-list']}><span className={generalUser["react-icon"]}><FcFilm /></span>シーン数</p>
               <div>数字</div>
             </div>
+          </div>
+          <div className={generalUser["detail-area-link"]}>
+            <Link to={`/users/${userId}/comics`} className={generalUser["link-show"]} ><span className={generalUser["react-icon"]}><FcMms /></span>漫画を見る</Link>
           </div>
         </div>
       </div>

--- a/frontend/app/src/components/model/user/ui/GeneralUserCard.js
+++ b/frontend/app/src/components/model/user/ui/GeneralUserCard.js
@@ -1,0 +1,51 @@
+import generalUser from "../../../../css/model/user/generalUser.module.css";
+import reactStringReplace from "react-string-replace";
+import noimage from "../../../../image/default.png";
+import { useGeneralUser } from '../../../../hooks/useGeneralUser';
+import { FcVoicePresentation, FcDocument, FcFilm, FcReading, FcPodiumWithSpeaker } from "react-icons/fc";
+
+const GeneralUserCard = ({
+  userId,
+  userName,
+  userImage,
+  userIntroduction,
+  userUrl
+}) => {
+  const regExp = /(https?:\/\/\S+)/g;
+  const { useGetGeneralUserComic } = useGeneralUser();
+
+  const { data: comic, isLoading } = useGetGeneralUserComic(userId);
+  if(isLoading) return <></>
+
+  return (
+    <div className={generalUser.content}>
+      <div className={generalUser["innner-content"]}>
+        <div className={generalUser.list}>
+          <div className={generalUser["user-name"]}><img className={generalUser["user-image"]} src={ userImage } alt='画像' onError={(e) => e.target.src = noimage} /><span className={generalUser["react-icon"]}><FcPodiumWithSpeaker /></span>ユーザー名&nbsp;<span className={generalUser["user-name-text"]}>{ userName }</span></div>
+          <div className={generalUser['detail-area']}>
+            <p className={generalUser.detail}><span className={generalUser["react-icon"]}><FcVoicePresentation /></span>自己紹介</p>
+            <div>{ userIntroduction }</div>
+          </div>
+          <div className={generalUser['detail-area']}>
+            <p className={generalUser.detail}><span className={generalUser["react-icon"]}><FcDocument /></span>webサイトリンク</p>
+            {reactStringReplace(userUrl, regExp, (match, i) => (
+              <a className={generalUser.a} key={i} href={match}>{match}</a>
+            ))}
+          </div>
+          <div className={generalUser['detail-area-count']}>
+            <div className={generalUser["detail-area-list"]}>
+              <p className={generalUser['detail-list']}><span className={generalUser["react-icon"]}><FcReading /></span>漫画数</p>
+              <div>{ comic.length }</div>
+            </div>
+            <div className={generalUser["detail-area-list"]}>
+              <p className={generalUser['detail-list']}><span className={generalUser["react-icon"]}><FcFilm /></span>シーン数</p>
+              <div>数字</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GeneralUserCard;

--- a/frontend/app/src/components/ui/BurgerMenu.js
+++ b/frontend/app/src/components/ui/BurgerMenu.js
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+import { slide as Menu } from 'react-burger-menu';
+import '../../css/BurgerMenu.css';
+import sideBar from '../../css/ui/sideBar.module.css';
+import { AuthContext } from '../../providers/AuthGuard';
+import { useContext, useState } from 'react';
+import { FcPortraitMode, FcViewDetails, FcImport, FcHome, FcRight, FcVoicePresentation, FcReading, FcNook } from "react-icons/fc";
+
+const BurgerMenu = () => {
+  const { isAuthenticated, loginWithRedirect, logout } = useContext(AuthContext);
+  const [ open, setOpen ] = useState(false);
+
+  const handleStateChange = state => {
+    setOpen(state.isOpen)
+  }
+
+  const closeMenu = () => {
+    setOpen(false)
+  }
+
+  return (
+    <Menu isOpen={open} onStateChange={state => handleStateChange(state)} right customBurgerIcon={
+      <div className={sideBar["menu-icon"]}><FcViewDetails /></div>
+    }>
+      <Link to="/" onClick={() => closeMenu()}><span className={sideBar["react-icon"]}><FcHome /></span>ホーム</Link>
+      <Link to="/users" onClick={() => closeMenu()}><span className={sideBar["react-icon"]}><FcPortraitMode /></span>ユーザー一覧</Link>
+      <Link to="/comic" onClick={() => closeMenu()}><span className={sideBar["react-icon"]}><FcReading /></span>漫画一覧</Link>
+      { isAuthenticated ?
+        <Link onClick={() => logout({ returnTo: window.location.origin })}><span className={sideBar["react-icon"]}><FcImport /></span>ログアウト</Link>
+        :
+        <Link onClick={() => loginWithRedirect({ redirect_url: window.location.origin })}><span className={sideBar["react-icon"]}><FcRight /></span>新規登録/ログイン</Link>
+      }
+      { isAuthenticated ?
+        <Link to="/mypage" onClick={() => closeMenu()}><span className={sideBar["react-icon"]}><FcVoicePresentation /></span>マイページ</Link>
+        :
+        <Link onClick={() => loginWithRedirect({ redirect_url: window.location.origin })}><span className={sideBar["react-icon"]}><FcVoicePresentation /></span>マイページ</Link>
+      }
+      <Link to="/privacy-policy" onClick={() => closeMenu()}><span className={sideBar["react-icon"]}><FcNook /></span>プライバシーポリシー</Link>
+      <Link to="/terms-of-service" onClick={() => closeMenu()}><span className={sideBar["react-icon"]}><FcNook /></span>利用規約</Link>
+    </Menu>
+  );
+};
+
+export default BurgerMenu;

--- a/frontend/app/src/components/ui/FavoriteButton.js
+++ b/frontend/app/src/components/ui/FavoriteButton.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import { useContext } from "react";
 import { useForm } from "react-hook-form";
 import { AuthContext } from "../../providers/AuthGuard";
-import { BsBookmark } from "react-icons/bs";
+import { FcLikePlaceholder } from "react-icons/fc";
 import generalScenePost from '../../css/model/general/generalScenePost.module.css';
 
 const FavoriteButton = ({id, changeFavorite}) => {
@@ -28,7 +28,7 @@ const FavoriteButton = ({id, changeFavorite}) => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <input {...register('scene_post_id', { value: id })} type='hidden' />
-      <button type='submit' className={generalScenePost.favorite}><BsBookmark /></button>
+      <button type='submit' className={generalScenePost.favorite}><FcLikePlaceholder /></button>
     </form>
   );
 };

--- a/frontend/app/src/components/ui/FavoriteButton.js
+++ b/frontend/app/src/components/ui/FavoriteButton.js
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import { useForm } from "react-hook-form";
 import { AuthContext } from "../../providers/AuthGuard";
 import { BsBookmark } from "react-icons/bs";
-import generalScenePostCss from '../../css/model/general/generalScenePostCss.module.css';
+import generalScenePost from '../../css/model/general/generalScenePost.module.css';
 
 const FavoriteButton = ({id, changeFavorite}) => {
   const { token } = useContext(AuthContext);
@@ -28,7 +28,7 @@ const FavoriteButton = ({id, changeFavorite}) => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <input {...register('scene_post_id', { value: id })} type='hidden' />
-      <button type='submit' className={generalScenePostCss.favorite}><BsBookmark /></button>
+      <button type='submit' className={generalScenePost.favorite}><BsBookmark /></button>
     </form>
   );
 };

--- a/frontend/app/src/components/ui/UnFavoriteButton.js
+++ b/frontend/app/src/components/ui/UnFavoriteButton.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import { useContext } from "react";
 import { AuthContext } from "../../providers/AuthGuard";
 import { BsBookmarkFill } from "react-icons/bs";
-import generalScenePostCss from '../../css/model/general/generalScenePostCss.module.css';
+import generalScenePost from '../../css/model/general/generalScenePost.module.css';
 
 const UnFavoriteButton = ({id, changeFavorite}) => {
   const { token } = useContext(AuthContext);
@@ -23,7 +23,7 @@ const UnFavoriteButton = ({id, changeFavorite}) => {
   }
 
   return (
-    <button type='button' onClick={handleDelete} className={generalScenePostCss.unfavorite}><BsBookmarkFill /></button>
+    <button type='button' onClick={handleDelete} className={generalScenePost.unfavorite}><BsBookmarkFill /></button>
   );
 };
 

--- a/frontend/app/src/components/ui/UnFavoriteButton.js
+++ b/frontend/app/src/components/ui/UnFavoriteButton.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useContext } from "react";
 import { AuthContext } from "../../providers/AuthGuard";
-import { BsBookmarkFill } from "react-icons/bs";
+import { FcLike } from "react-icons/fc";
 import generalScenePost from '../../css/model/general/generalScenePost.module.css';
 
 const UnFavoriteButton = ({id, changeFavorite}) => {
@@ -23,7 +23,7 @@ const UnFavoriteButton = ({id, changeFavorite}) => {
   }
 
   return (
-    <button type='button' onClick={handleDelete} className={generalScenePost.unfavorite}><BsBookmarkFill /></button>
+    <button type='button' onClick={handleDelete} className={generalScenePost.favorite}><FcLike /></button>
   );
 };
 

--- a/frontend/app/src/css/BurgerMenu.css
+++ b/frontend/app/src/css/BurgerMenu.css
@@ -1,0 +1,57 @@
+.bm-burger-button {
+  position: fixed;
+  width: 36px;
+  height: 30px;
+  right: 10px;
+  top: 20px;
+}
+
+.bm-burger-bars {
+  background: #373a47;
+}
+
+.bm-burger-bars-hover {
+  background: #a90000;
+}
+
+.bm-cross-button {
+  height: 24px;
+  width: 24px;
+}
+
+.bm-cross {
+  background: black;
+}
+
+.bm-menu-wrap {
+  position: fixed;
+  height: 100%;
+}
+
+.bm-menu {
+  background: #f2f1dd;
+  padding: 2.5em 1.5em 0;
+  font-size: 1.15em;
+}
+
+.bm-morph-shape {
+  fill: #373a47;
+}
+
+.bm-item-list {
+  padding: 0.8em;
+}
+
+.bm-overlay {
+  top: 0px;
+  right: 0px;
+  background: rgba(0, 0, 255, 0);
+}
+
+.bm-item {
+  display: inline-block;
+  margin-bottom: 10px;
+  text-align: left;
+  text-decoration: none;
+  transition: color 0.2s;
+}

--- a/frontend/app/src/css/header.module.css
+++ b/frontend/app/src/css/header.module.css
@@ -23,15 +23,51 @@
 
 .nav-li-text {
   text-decoration: none;
-  background-color: aqua;
+  background-color: #87cefa;
   border: none;
   border-radius: 24px;
-  padding: 10px 20px;
+  padding: 7px 10px;
   font-size: 15px;
   box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+  font-weight: bold;
 }
 
 .nav-li-text:hover {
+  opacity: 0.5;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
+}
+
+.nav-comic {
+  background-color: #ffc0cb;
+  text-decoration: none;
+  border: none;
+  border-radius: 24px;
+  padding: 7px 10px;
+  font-size: 15px;
+  font-weight: bold;
+  box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+}
+
+.nav-comic:hover {
+  opacity: 0.5;
+}
+
+.nav-sign-in {
+  text-decoration: none;
+  border: none;
+  border-radius: 24px;
+  padding: 7px 10px;
+  font-size: 15px;
+  font-weight: bold;
+  box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+}
+
+.nav-sign-in:hover {
   opacity: 0.5;
 }
 

--- a/frontend/app/src/css/header.module.css
+++ b/frontend/app/src/css/header.module.css
@@ -21,6 +21,10 @@
   margin-right: 10px;
 }
 
+.side {
+  display: none;
+}
+
 .nav-li-text {
   text-decoration: none;
   background-color: #87cefa;
@@ -92,7 +96,12 @@
   }
   
   .li {
+    display: none;
     margin-right: 7px;
+  }
+
+  .side {
+    display: inline-block;
   }
   
   .nav-li-text {

--- a/frontend/app/src/css/home.module.css
+++ b/frontend/app/src/css/home.module.css
@@ -62,6 +62,7 @@
 }
 
 .post-title-link {
+  font-weight: bold;
   background-color: greenyellow;
   padding: 16px 40px;
   border-radius: 24px;

--- a/frontend/app/src/css/model/comicPost.module.css
+++ b/frontend/app/src/css/model/comicPost.module.css
@@ -22,13 +22,6 @@
   border-radius: 5px;
 }
 
-.bs-search {
-  color: palevioletred;
-  margin-right: 4px;
-  font-size: 29px;
-  vertical-align: -5px;
-}
-
 .detail-result {
   text-align: center;
   margin-top: 80px;
@@ -47,6 +40,7 @@
 }
 
 .innner-content {
+  border-radius: 10px;
   border: 2px solid #a9a9a9;
   background-color: #f0f8ff;
   margin-bottom: 10px;
@@ -84,20 +78,6 @@
 .react-icon {
   font-size: 24px;
   vertical-align: -6px;
-  margin-right: 1px;
-}
-
-.bs-book-fill {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -4px;
-  margin-right: 1px;
-}
-
-.bs-journal-book-mark-fill {
-  color: green;
-  font-size: 16px;
-  vertical-align: -4px;
   margin-right: 1px;
 }
 
@@ -141,13 +121,6 @@
 .create-at {
   text-align: center;
   margin: 20px 0px;
-}
-
-.bs-calender-3 {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -2px;
-  margin-right: 3px;
 }
 
 .detail-text {

--- a/frontend/app/src/css/model/comicPost.module.css
+++ b/frontend/app/src/css/model/comicPost.module.css
@@ -22,6 +22,12 @@
   border-radius: 5px;
 }
 
+.fc-search {
+  margin-right: 4px;
+  font-size: 32px;
+  vertical-align: -7px;
+}
+
 .detail-result {
   text-align: center;
   margin-top: 80px;

--- a/frontend/app/src/css/model/comicPost.module.css
+++ b/frontend/app/src/css/model/comicPost.module.css
@@ -75,9 +75,16 @@
 }
 
 .detail {
+  color: #ff8c00;
   text-align: center;
   margin-bottom: 10px;
   font-weight: bold;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
 }
 
 .bs-book-fill {
@@ -95,7 +102,7 @@
 }
 
 .link-list {
-  padding: 20px;
+  padding: 10px;
   margin-bottom: 20px;
   text-align: center;
 }
@@ -105,7 +112,7 @@
   border-radius: 5px;
   box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
   font-size: 15px;
-  font-weight: 700;
+  font-weight: bold;
   padding: 14px 6px;
   background-color: #4682b4;
   color: white;
@@ -120,7 +127,7 @@
   border-radius: 5px;
   box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
   font-size: 15px;
-  font-weight: 700;
+  font-weight: bold;
   margin-left: 20px;
   padding: 14px 6px;
   background-color: #a9a9a9;
@@ -171,12 +178,15 @@
     width: 100%;
   }
 
-  .bs-book-fill {
-    font-size: 13px;
+  .react-icon {
+    font-size: 17px;
+    vertical-align: -4px;
   }
 
-  .bs-journal-book-mark-fill {
-    font-size: 13px;
+  .link-list {
+    padding: 7px;
+    margin-bottom: 20px;
+    text-align: center;
   }
 
   .link-show {

--- a/frontend/app/src/css/model/comment/comment.module.css
+++ b/frontend/app/src/css/model/comment/comment.module.css
@@ -28,6 +28,12 @@
   margin-right: 20px;
 }
 
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
+}
+
 .delete-button {
   text-decoration: none;
   background-color: red;
@@ -55,14 +61,14 @@
   margin: 20px 0px;
 }
 
-.bs-calender-3 {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -2px;
-  margin-right: 3px;
-}
-
 .detail-text {
   width: fit-content;
   border-bottom: 2px solid #a9a9a9;
+}
+
+@media screen and (max-width: 540px) {
+  .react-icon {
+    font-size: 17px;
+    vertical-align: -4px;
+  }
 }

--- a/frontend/app/src/css/model/general/generalComic.module.css
+++ b/frontend/app/src/css/model/general/generalComic.module.css
@@ -53,11 +53,17 @@
 }
 
 .innner-content {
+  border-radius: 10px;
   display: flex;
   border: 2px solid #a9a9a9;
   background-color: #f0f8ff;
   margin-bottom: 10px;
-  font-weight: bold;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
 }
 
 .user-name {
@@ -79,27 +85,15 @@
 }
 
 .detail {
+  font-weight: bold;
+  color: #ff8c00;
   text-align: center;
   margin-bottom: 10px;
-}
-
-.bs-book-fill {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -4px;
-  margin-right: 3px;
 }
 
 .detail-text {
   width: fit-content;
   border-bottom: 2px solid #a9a9a9;
-}
-
-.bs-journal-book-mark-fill {
-  color: green;
-  font-size: 16px;
-  vertical-align: -4px;
-  margin-right: 3px;
 }
 
 .detail-area-link {
@@ -132,13 +126,6 @@
 .create-at {
   text-align: center;
   margin: 20px 0px;
-}
-
-.bs-calender-3 {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -2px;
-  margin-right: 3px;
 }
 
 .image {
@@ -176,7 +163,7 @@
     box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
     font-size: 15px;
     margin: 10px;
-    padding: 9px 16px;
+    padding: 8px 13px;
   }
 
   .outer-image {
@@ -197,6 +184,12 @@
     font-size: 13px;
     padding: 10px 15px;
     display: block;
+  }
+
+  .react-icon {
+    font-size: 18px;
+    vertical-align: -3px;
+    margin-right: 1px;
   }
 
   .content {
@@ -223,18 +216,6 @@
     margin-bottom: 4px;
   }
 
-  .bs-book-fill {
-    font-size: 15px;
-    vertical-align: -2.5px;
-    margin-right: 2px;
-  }
-
-  .bs-journal-book-mark-fill {
-    font-size: 15px;
-    vertical-align: -2.5px;
-    margin-right: 2px;
-  }
-
   .detail-area-link {
     margin-top: 20px;
     margin-bottom: 20px;
@@ -242,7 +223,7 @@
 
   .link-show {
     margin: 9px;
-    padding: 7px;
+    padding: 8px 3px;
     font-size: 13px;
   }
 

--- a/frontend/app/src/css/model/general/generalComic.module.css
+++ b/frontend/app/src/css/model/general/generalComic.module.css
@@ -26,11 +26,10 @@
   border-radius: 5px;
 }
 
-.bs-search {
-  color: palevioletred;
+.fc-search {
   margin-right: 4px;
-  font-size: 29px;
-  vertical-align: -5px;
+  font-size: 32px;
+  vertical-align: -7px;
 }
 
 .detail-result {
@@ -41,14 +40,14 @@
 }
 
 .main-content {
-  padding: 121px;
+  padding: 30px;
   justify-content: space-between;
   display: flex;
   flex-wrap: wrap;
 }
 
 .content {
-  width: 46%;
+  width: 49%;
   margin-top: 20px;
 }
 

--- a/frontend/app/src/css/model/general/generalComic.module.css
+++ b/frontend/app/src/css/model/general/generalComic.module.css
@@ -161,8 +161,8 @@
     border-radius: 5px;
     box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
     font-size: 15px;
-    margin: 10px;
-    padding: 8px 13px;
+    margin: 5px;
+    padding: 8px 10px;
   }
 
   .outer-image {

--- a/frontend/app/src/css/model/general/generalScenePost.module.css
+++ b/frontend/app/src/css/model/general/generalScenePost.module.css
@@ -276,6 +276,17 @@
     height: 150px;
   }
 
+  .favorite-outer-image {
+    height: 120px;
+    width: 100%;
+  }
+  
+  .favorite-image {
+    height: 120px;
+    width: 100%;
+    object-fit: contain;
+  }
+
   .list {
     padding: 10px;
   }

--- a/frontend/app/src/css/model/general/generalScenePost.module.css
+++ b/frontend/app/src/css/model/general/generalScenePost.module.css
@@ -154,6 +154,10 @@
   display: inline;
 }
 
+.favorite-count {
+  margin-left: 8px;
+}
+
 .favorite {
   border: none;
   background-color: #f0f8ff;

--- a/frontend/app/src/css/model/general/generalScenePost.module.css
+++ b/frontend/app/src/css/model/general/generalScenePost.module.css
@@ -159,16 +159,7 @@
   background-color: #f0f8ff;
   vertical-align: -3px;
   margin-right: 3px;
-  font-size: 22px;
-}
-
-.unfavorite {
-  border: none;
-  background-color: #f0f8ff;
-  vertical-align: -3px;
-  margin-right: 3px;
-  color: #ffd700;
-  font-size: 22px;
+  font-size: 27px;
 }
 
 .detail-area-count {

--- a/frontend/app/src/css/model/general/generalScenePost.module.css
+++ b/frontend/app/src/css/model/general/generalScenePost.module.css
@@ -29,6 +29,18 @@
   border-radius: 5px;
 }
 
+.fc-search {
+  margin-right: 4px;
+  font-size: 32px;
+  vertical-align: -7px;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
+}
+
 .detail-result {
   text-align: center;
   margin-top: 80px;

--- a/frontend/app/src/css/model/general/generalScenePostCss.module.css
+++ b/frontend/app/src/css/model/general/generalScenePostCss.module.css
@@ -29,13 +29,6 @@
   border-radius: 5px;
 }
 
-.bs-search {
-  color: palevioletred;
-  margin-right: 4px;
-  font-size: 29px;
-  vertical-align: -5px;
-}
-
 .detail-result {
   text-align: center;
   margin-top: 80px;
@@ -53,7 +46,12 @@
   border: 2px solid #a9a9a9;
   background-color: #f0f8ff;
   margin-bottom: 10px;
-  font-weight: bold;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
 }
 
 .user-name {
@@ -75,27 +73,15 @@
 }
 
 .detail {
+  font-weight: bold;
+  color: #ff8c00;
   text-align: center;
   margin-bottom: 10px;
-}
-
-.bs-book-fill {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -4px;
-  margin-right: 3px;
 }
 
 .detail-text {
   width: fit-content;
   border-bottom: 2px solid #a9a9a9;
-}
-
-.bs-journal-book-mark-fill {
-  color: green;
-  font-size: 16px;
-  vertical-align: -4px;
-  margin-right: 3px;
 }
 
 .detail-area-link {
@@ -125,16 +111,20 @@
   width: 100%;
 }
 
+.favorite-outer-image {
+  height: 220px;
+  width: 100%;
+}
+
+.favorite-image {
+  height: 220px;
+  width: 100%;
+  object-fit: contain;
+}
+
 .create-at {
   text-align: center;
   margin: 20px 0px;
-}
-
-.bs-calender-3 {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -2px;
-  margin-right: 3px;
 }
 
 .image {
@@ -181,13 +171,6 @@
   text-align: center;
 }
 
-.bs-fill-chat-right-dots-fill {
-  color: #a9a9a9;
-  font-size: 16px;
-  vertical-align: -3px;
-  margin-right: 3px;
-}
-
 @media screen and (min-width: 541px) and (max-width: 1024px) {
   .main-content {
     padding: 10px;
@@ -204,15 +187,14 @@
 
   .detail-area-link {
     margin-top: 25px;
-    margin-bottom: 25px;
   }
 
   .link-show {
     border-radius: 5px;
     box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
     font-size: 15px;
-    margin: 10px;
-    padding: 9px 16px;
+    margin: 5px;
+    padding: 8px 10px;
   }
 
   .outer-image {
@@ -268,26 +250,19 @@
     margin-bottom: 4px;
   }
 
-  .bs-book-fill {
-    font-size: 15px;
-    vertical-align: -2.5px;
-    margin-right: 2px;
-  }
-
-  .bs-journal-book-mark-fill {
-    font-size: 15px;
-    vertical-align: -2.5px;
-    margin-right: 2px;
-  }
-
   .detail-area-link {
     margin-top: 20px;
   }
 
   .link-show {
     margin: 9px;
-    padding: 7px;
+    padding: 8px 3px;
     font-size: 13px;
+  }
+
+  .react-icon {
+    font-size: 17px;
+    vertical-align: -4px;
   }
 
   .outer-image {

--- a/frontend/app/src/css/model/mypage/favorite.module.css
+++ b/frontend/app/src/css/model/mypage/favorite.module.css
@@ -22,11 +22,10 @@
   border-radius: 5px;
 }
 
-.bs-search {
-  color: palevioletred;
+.fc-search {
   margin-right: 4px;
-  font-size: 29px;
-  vertical-align: -5px;
+  font-size: 32px;
+  vertical-align: -7px;
 }
 
 .detail-result {

--- a/frontend/app/src/css/model/profile.module.css
+++ b/frontend/app/src/css/model/profile.module.css
@@ -118,4 +118,9 @@
   .content {
     width: 100%;
   }
+
+  .react-icon {
+    font-size: 20px;
+    vertical-align: -4px;
+  }
 }

--- a/frontend/app/src/css/model/profile.module.css
+++ b/frontend/app/src/css/model/profile.module.css
@@ -15,6 +15,18 @@
   border-radius: 6px;
 }
 
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
+}
+
+.detail-profile {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  font-weight: bold;
+}
+
 .detail-area {
   text-align: center;
   margin-top: 20px;
@@ -28,6 +40,7 @@
 }
 
 .detail {
+  color: #ff8c00;
   margin-top: 20px;
   margin-bottom: 20px;
   font-weight: bold;

--- a/frontend/app/src/css/model/scene_post/scenePost.module.css
+++ b/frontend/app/src/css/model/scene_post/scenePost.module.css
@@ -26,11 +26,16 @@
   border-radius: 5px;
 }
 
-.bs-search {
-  color: palevioletred;
+.fc-search {
   margin-right: 4px;
-  font-size: 29px;
-  vertical-align: -5px;
+  font-size: 32px;
+  vertical-align: -7px;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
 }
 
 .detail-result {
@@ -75,6 +80,7 @@
   background-color: #f0f8ff;
   border: 2px solid black;
   border-radius: 15px;
+  font-weight: bold;
   padding: 10px 20px;
   margin: 20px;
   font-size: 15px;
@@ -86,17 +92,18 @@
 }
 
 .main-content {
-  padding: 121px;
+  padding: 30px;
   justify-content: space-between;
   display: flex;
   flex-wrap: wrap;
 }
 
 .content {
-  width: 31%;
+  width: 32%;
 }
 
 .innner-content {
+  border-radius: 10px;
   border: 2px solid #a9a9a9;
   background: #f0f8ff;
   margin-bottom: 10px;
@@ -125,21 +132,10 @@
 }
 
 .detail {
+  color: #ff8c00;
   text-align: center;
   margin-bottom: 10px;
   font-weight: bold;
-}
-
-.bs-book-fill {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -4px;
-}
-
-.bs-journal-book-mark-fill {
-  color: green;
-  font-size: 16px;
-  vertical-align: -4px;
 }
 
 .link-list {
@@ -154,8 +150,7 @@
   box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
   font-size: 15px;
   font-weight: 700;
-  margin: 20px 20px;
-  padding: 11px 12px;
+  padding: 14px 6px;
   background-color: #4682b4;
   color: white;
 }
@@ -170,8 +165,8 @@
   box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
   font-size: 15px;
   font-weight: 700;
-  margin: 20px 20px;
-  padding: 11px 12px;
+  padding: 14px 6px;
+  margin-left: 20px;
   background-color: #a9a9a9;
   color: white;
 }
@@ -183,13 +178,6 @@
 .create-at {
   text-align: center;
   margin: 20px 0px;
-}
-
-.bs-calender-3 {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -2px;
-  margin-right: 3px;
 }
 
 .detail-text {
@@ -208,13 +196,6 @@
   margin-right: 10px;
   text-align: center;
   font-weight: bold;
-}
-
-.bs-fill-chat-right-dots-fill {
-  color: #a9a9a9;
-  font-size: 16px;
-  vertical-align: -3px;
-  margin-right: 3px;
 }
 
 @media screen and (min-width: 541px) and (max-width: 1024px) {
@@ -245,9 +226,25 @@
     font-size: 13px;
   }
 
+  .react-icon {
+    font-size: 17px;
+    vertical-align: -4px;
+  }
+
   .link-list {
-    padding: 0px;
-    margin-top: 20px;
-    margin-bottom: 40px;
+    padding: 7px;
+    margin-bottom: 20px;
+    text-align: center;
+  }
+
+  .link-show {
+    font-size: 13px;
+    padding: 10px 6px;
+  }
+
+  .link-edit {
+    font-size: 13px;
+    margin-left: 20px;
+    padding: 10px 6px;
   }
 }

--- a/frontend/app/src/css/model/scene_post/scenePostShow.module.css
+++ b/frontend/app/src/css/model/scene_post/scenePostShow.module.css
@@ -41,7 +41,13 @@
   height: 100%;
   border: 2px solid #a9a9a9;
   background-color: #f0f8ff;
-  border-radius: 6px;
+  border-radius: 10px;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
 }
 
 .outer-image {
@@ -72,51 +78,10 @@
 }
 
 .detail {
+  color: #ff8c00;
   margin-top: 20px;
   margin-bottom: 20px;
   font-weight: bold;
-}
-
-.bs-book-fill {
-  color: blue;
-  font-size: 22px;
-  vertical-align: -4px;
-  margin-right: 10px;
-}
-
-.bs-fill-pencil-fill {
-  color: red;
-  font-size: 20px;
-  vertical-align: -4px;
-  margin-right: 7px;
-}
-
-.bs-receipt {
-  color: hotpink;
-  font-size: 20px;
-  vertical-align: -4px;
-  margin-right: 7px;
-}
-
-.bs-fill-journal-bookmark-fill {
-  color: green;
-  font-size: 20px;
-  vertical-align: -4px;
-  margin-right: 7px;
-}
-
-.bs-calender-3 {
-  color: palevioletred;
-  font-size: 20px;
-  vertical-align: -4px;
-  margin-right: 7px;
-}
-
-.bs-newspaper {
-  color: gold;
-  font-size: 20px;
-  vertical-align: -4px;
-  margin-right: 7px;
 }
 
 .back {
@@ -139,22 +104,9 @@
   margin: 20px 0px;
 }
 
-.bs-calender-3 {
-  color: blue;
-  font-size: 16px;
-  vertical-align: -2px;
-  margin-right: 3px;
-}
-
 .detail-text {
   width: fit-content;
   border-bottom: 2px solid #a9a9a9;
-}
-
-.bs-fill-replay-fill {
-  font-size: 22px;
-  vertical-align: -4px;
-  margin-right: 10px;
 }
 
 .detail-area-comment {
@@ -183,13 +135,6 @@
   font-weight: bold;
 }
 
-.bs-fill-chat-right-dots-fill {
-  color: #a9a9a9;
-  font-size: 16px;
-  vertical-align: -3px;
-  margin-right: 3px;
-}
-
 @media screen and (min-width: 541px) and (max-width: 1024px) {
   .react-icons {
     vertical-align: -1px;
@@ -211,31 +156,6 @@
   .detail {
     margin-top: 10px;
     margin-bottom: 10px;
-  }
-
-  .bs-book-fill {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-
-  .bs-fill-pencil-fill {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-
-  .bs-fill-journal-bookmark-fill {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-
-  .bs-calender-3 {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-
-  .bs-newspaper {
-    vertical-align: -1px;
-    margin-right: 3px;
   }
 
   .back {
@@ -260,6 +180,10 @@
     padding: 10px;
   }
 
+  .comic-title {
+    font-size: 18px;
+  }
+
   .outer-image {
     height: 100%;
     width: 100%;
@@ -274,29 +198,9 @@
     margin-bottom: 10px;
   }
 
-  .bs-book-fill {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-
-  .bs-fill-pencil-fill {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-
-  .bs-fill-journal-bookmark-fill {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-  
-  .bs-calender-3 {
-    vertical-align: -1px;
-    margin-right: 3px;
-  }
-
-  .bs-newspaper {
-    vertical-align: -1px;
-    margin-right: 3px;
+  .react-icon {
+    font-size: 17px;
+    vertical-align: -4px;
   }
 
   .back {

--- a/frontend/app/src/css/model/user/generalUser.module.css
+++ b/frontend/app/src/css/model/user/generalUser.module.css
@@ -1,0 +1,100 @@
+.main-content {
+  padding: 30px;
+  justify-content: space-between;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.content {
+  width: 49%;
+  margin-top: 20px;
+}
+
+.list {
+  padding: 15px;
+  width: 100%;
+  text-align: center;
+}
+
+.innner-content {
+  border: 2px solid #a9a9a9;
+  background-color: #f0f8ff;
+  margin-bottom: 10px;
+}
+
+.user-name {
+  font-weight: bold;
+  color: #ff8c00;
+  padding-bottom: 15px;
+  margin-bottom: 10px;
+  border-bottom: 1.5px solid #a9a9a9;
+}
+
+.user-name-text {
+  color: black;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
+}
+
+.user-image {
+  height: 50px;
+  width: 50px;
+  border-radius: 100px;
+  vertical-align: middle;
+  margin-right: 20px;
+}
+
+.detail-area {
+  padding-bottom: 15px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 1.5px solid #a9a9a9;
+}
+
+.detail {
+  color: #ff8c00;
+  margin-bottom: 10px;
+  font-weight: bold;
+}
+
+.a {
+  text-decoration-line: underline;
+}
+
+.a:hover {
+  color: blue;
+}
+
+.detail-area-count {
+  margin: 20px 0px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.detail-area-list {
+  width: 100%;
+  margin-right: 10px;
+  text-align: center;
+}
+
+.detail-list {
+  color: #ff8c00;
+  font-weight: bold;
+}
+
+@media screen and (max-width: 540px) {
+  .main-content {
+    font-size: 13px;
+    padding: 10px;
+    display: block;
+  }
+
+  .content {
+    width: 100%;
+    margin-top: 20px;
+  }
+}

--- a/frontend/app/src/css/model/user/generalUser.module.css
+++ b/frontend/app/src/css/model/user/generalUser.module.css
@@ -70,9 +70,11 @@
 }
 
 .detail-area-count {
+  padding-bottom: 15px;
   margin: 20px 0px;
   display: flex;
   justify-content: space-between;
+  border-bottom: 1.5px solid #a9a9a9;
 }
 
 .detail-area-list {
@@ -84,6 +86,28 @@
 .detail-list {
   color: #ff8c00;
   font-weight: bold;
+}
+
+.detail-area-link {
+  margin-top: 40px;
+  margin-bottom: 40px;
+  text-align: center;
+}
+
+.link-show {
+  border: 2px solid #a9a9a9;
+  border-radius: 5px;
+  box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+  font-size: 15px;
+  font-weight: 700;
+  margin: 20px 20px;
+  padding: 14px 24px;
+  background-color: #4682b4;
+  color: white;
+}
+
+.link-show:hover {
+  opacity: 0.5;
 }
 
 @media screen and (max-width: 540px) {

--- a/frontend/app/src/css/ui/form.module.css
+++ b/frontend/app/src/css/ui/form.module.css
@@ -3,8 +3,15 @@
 }
 
 .form {
+  border-radius: 10px;
   border: 2px solid #a9a9a9;
   background-color: #f0f8ff;
+}
+
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 1px;
 }
 
 .form-text {
@@ -159,5 +166,10 @@
     border-radius: 5px;
     box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
     padding: 12px 8px;
+  }
+
+  .react-icon {
+    font-size: 20px;
+    vertical-align: -4px;
   }
 }

--- a/frontend/app/src/css/ui/form.module.css
+++ b/frontend/app/src/css/ui/form.module.css
@@ -134,7 +134,7 @@
   }
 
   .form-text {
-    margin: 0px;
+    margin: 20px;
   }
 
   .form-text-delete {

--- a/frontend/app/src/css/ui/sideBar.module.css
+++ b/frontend/app/src/css/ui/sideBar.module.css
@@ -1,0 +1,9 @@
+.react-icon {
+  font-size: 24px;
+  vertical-align: -6px;
+  margin-right: 10px;
+}
+
+.menu-icon {
+  font-size: 40px;
+}

--- a/frontend/app/src/hooks/useComic.js
+++ b/frontend/app/src/hooks/useComic.js
@@ -107,5 +107,14 @@ export const useComic = () => {
     );
   };
 
-  return { useGetComic, useCreateComic, useDeleteComic, usePutComic, useShowComic };
+  const useGetScenePostCount = () => {
+    return useQuery({
+      queryKey: 'scene_post_count',
+      queryFn: () => comic.getScenePostCount(token),
+      staleTime: 300000,
+      cacheTime: 0,
+    });
+  };
+
+  return { useGetComic, useCreateComic, useDeleteComic, usePutComic, useShowComic, useGetScenePostCount };
 };

--- a/frontend/app/src/hooks/useFavorite.js
+++ b/frontend/app/src/hooks/useFavorite.js
@@ -15,5 +15,20 @@ export const useFavorite = () => {
     });
   };
 
-  return { useGetFavorite };
+  const useGetFavorites_count = (scenePostId) => {
+    return useQuery({
+      queryKey: [
+        'favorites_count',
+      { scenePostId: scenePostId },
+      ],
+      queryFn: () =>
+        favorite.getFavorites_count(
+          scenePostId
+        ),
+      staleTime: 30000000,
+      cacheTime: 0,
+    });
+  };
+
+  return { useGetFavorite, useGetFavorites_count };
 };

--- a/frontend/app/src/hooks/useGeneralUser.js
+++ b/frontend/app/src/hooks/useGeneralUser.js
@@ -1,0 +1,44 @@
+import { useQuery } from "react-query";
+import { generalUser } from "../api/generalUser";
+
+export const useGeneralUser = () => {
+  const useGetGeneralUser = () => {
+    return useQuery({
+      queryKey: 'general_user',
+      queryFn: () => generalUser.getGeneralUser(),
+      staleTime: 300000,
+      cacheTime: 0,
+    });
+  };
+
+  const useShowGeneralUser = (userId) => {
+    return useQuery({
+      queryKey: [
+        'general_user_show',
+        { userId: userId }
+      ],
+      queryFn: () => generalUser.showGeneralUser(
+        userId
+      ),
+      enabled: !!comicId,
+      staleTime: 30000000,
+      cacheTime: 0,
+    });
+  };
+
+  const useGetGeneralUserComic = (userId) => {
+    return useQuery({
+      queryKey: [
+        'general_user_comic',
+        { userId: userId }
+      ],
+      queryFn: () => generalUser.getGeneralUserComic(
+        userId
+      ),
+      staleTime: 30000000,
+      cacheTime: 0,
+    });
+  };
+
+  return { useGetGeneralUser, useShowGeneralUser, useGetGeneralUserComic };
+};

--- a/frontend/app/src/hooks/useGeneralUser.js
+++ b/frontend/app/src/hooks/useGeneralUser.js
@@ -20,7 +20,7 @@ export const useGeneralUser = () => {
       queryFn: () => generalUser.showGeneralUser(
         userId
       ),
-      enabled: !!comicId,
+      enabled: !!userId,
       staleTime: 30000000,
       cacheTime: 0,
     });

--- a/frontend/app/src/hooks/useGeneralUser.js
+++ b/frontend/app/src/hooks/useGeneralUser.js
@@ -6,7 +6,7 @@ export const useGeneralUser = () => {
     return useQuery({
       queryKey: 'general_user',
       queryFn: () => generalUser.getGeneralUser(),
-      staleTime: 300000,
+      staleTime: 30000000,
       cacheTime: 0,
     });
   };
@@ -40,5 +40,14 @@ export const useGeneralUser = () => {
     });
   };
 
-  return { useGetGeneralUser, useShowGeneralUser, useGetGeneralUserComic };
+  const useGetGeneralScenePostCount = () => {
+    return useQuery({
+      queryKey: 'general_scene_post_count',
+      queryFn: () => generalUser.getGeneralUserScenePostCount(),
+      staleTime: 30000000,
+      cacheTime: 0,
+    });
+  };
+
+  return { useGetGeneralUser, useShowGeneralUser, useGetGeneralUserComic, useGetGeneralScenePostCount };
 };

--- a/frontend/app/src/hooks/useGeneralUser.js
+++ b/frontend/app/src/hooks/useGeneralUser.js
@@ -40,10 +40,15 @@ export const useGeneralUser = () => {
     });
   };
 
-  const useGetGeneralScenePostCount = () => {
+  const useGetGeneralScenePostCount = (userId) => {
     return useQuery({
-      queryKey: 'general_scene_post_count',
-      queryFn: () => generalUser.getGeneralUserScenePostCount(),
+      queryKey: [
+        'general_scene_post_count',
+        { userId: userId }
+      ],
+      queryFn: () => generalUser.getGeneralUserScenePostCount(
+        userId
+      ),
       staleTime: 30000000,
       cacheTime: 0,
     });

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -19,3 +19,4 @@ export { default as Page404 } from '../components/error/Page404';
 export { default as MyProfile } from '../components/model/profile/MyProfile';
 export { default as CommentNew } from '../components/model/comment/CommentNew';
 export { default as GeneralUser } from '../components/model/user/GeneralUser';
+export { default as GeneralUserComic } from '../components/model/user/GeneralUserComic';

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -18,3 +18,4 @@ export { default as ComicPost } from '../components/model/mypage/ComicPost';
 export { default as Page404 } from '../components/error/Page404';
 export { default as MyProfile } from '../components/model/profile/MyProfile';
 export { default as CommentNew } from '../components/model/comment/CommentNew';
+export { default as GeneralUser } from '../components/model/user/GeneralUser';

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -16,7 +16,8 @@ import {
   Page404,
   MyProfile,
   CommentNew,
-  GeneralUser
+  GeneralUser,
+  GeneralUserComic
 } from './Pages';
 
 const Routers = () => {
@@ -39,6 +40,7 @@ const Routers = () => {
       <Route path='/my-profile/:user_id' element={ <ProtectedRoute component={MyProfile}/> } />
       <Route path='/general_scene_post/:comic_title/:scene_post_id/comment' element={ <ProtectedRoute component={CommentNew}/> } />
       <Route path='/users' element={ <GeneralUser /> } />
+      <Route path='/users/:user_id/comics' element={ <GeneralUserComic /> } />
     </Routes>
   );
 };

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -15,7 +15,8 @@ import {
   GeneralScenePostShow,
   Page404,
   MyProfile,
-  CommentNew
+  CommentNew,
+  GeneralUser
 } from './Pages';
 
 const Routers = () => {
@@ -37,6 +38,7 @@ const Routers = () => {
       <Route path='*' element={ <Page404 /> } />
       <Route path='/my-profile/:user_id' element={ <ProtectedRoute component={MyProfile}/> } />
       <Route path='/general_scene_post/:comic_title/:scene_post_id/comment' element={ <ProtectedRoute component={CommentNew}/> } />
+      <Route path='/users' element={ <GeneralUser /> } />
     </Routes>
   );
 };

--- a/frontend/app/yarn.lock
+++ b/frontend/app/yarn.lock
@@ -2508,6 +2508,11 @@ ajv@^8.0.0, ajv@^8.6.0, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
+
 ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   version "4.3.2"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz"
@@ -2681,10 +2686,24 @@ asap@~2.0.6:
   resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
+ast-transform@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/ast-transform/-/ast-transform-0.0.0.tgz#74944058887d8283e189d954600947bc98fe0062"
+  integrity sha512-e/JfLiSoakfmL4wmTGPjv0HpTICVmxwXgYOB8x+mzozHL8v+dSfCbrJ8J8hJ0YBP0XcYu1aLZ6b/3TnxNK3P2A==
+  dependencies:
+    escodegen "~1.2.0"
+    esprima "~1.0.4"
+    through "~2.3.4"
+
 ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
+
+ast-types@^0.7.0:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.7.8.tgz#902d2e0d60d071bdcd46dc115e1809ed11c138a9"
+  integrity sha512-RIOpVnVlltB6PcBJ5BMLx+H+6JJ/zjDGU0t7f0L6c2M1dqcK92VQopLBlPQ9R80AVXelfqYgjcPLtHtDbNFg0Q==
 
 async@^3.2.3:
   version "3.2.4"
@@ -2999,12 +3018,28 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
+browser-resolve@^1.8.1:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
+  dependencies:
+    resolve "1.1.7"
+
 browser-tabs-lock@^1.2.15:
   version "1.2.15"
   resolved "https://registry.yarnpkg.com/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz#d5012e652e2a0cb4eba471b0a2300c2fa5d92788"
   integrity sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==
   dependencies:
     lodash ">=4.17.21"
+
+browserify-optional@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-optional/-/browserify-optional-1.0.1.tgz#1e13722cfde0d85f121676c2a72ced533a018869"
+  integrity sha512-VrhjbZ+Ba5mDiSYEuPelekQMfTbhcA2DhLk2VQWqdcCROWeFqlTcXZ7yfRkXCIl8E+g4gINJYJiRB7WEtfomAQ==
+  dependencies:
+    ast-transform "0.0.0"
+    ast-types "^0.7.0"
+    browser-resolve "^1.8.1"
 
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.18.1, browserslist@^4.20.2, browserslist@^4.20.3, browserslist@^4.21.3:
   version "4.21.3"
@@ -3177,6 +3212,11 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+classnames@^2.2.6:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 clean-css@^5.2.2:
   version "5.3.1"
@@ -4085,6 +4125,17 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+escodegen@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.2.0.tgz#09de7967791cc958b7f89a2ddb6d23451af327e1"
+  integrity sha512-yLy3Cc+zAC0WSmoT2fig3J87TpQ8UaZGx8ahCAs9FL8qNbyV7CVyPKS74DG4bsHiL5ew9sxdYx131OkBQMFnvA==
+  dependencies:
+    esprima "~1.0.4"
+    estraverse "~1.5.0"
+    esutils "~1.0.0"
+  optionalDependencies:
+    source-map "~0.1.30"
+
 eslint-config-react-app@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz"
@@ -4374,6 +4425,11 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
+esprima@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
+  integrity sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==
+
 esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz"
@@ -4398,6 +4454,11 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estraverse@~1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
+  integrity sha512-FpCjJDfmo3vsc/1zKSeqR5k42tcIhxFIlvq+h9j0fO2q/h2uLKyweq7rYJ+0CoVvrGQOxIS5wyBrW/+vF58BUQ==
+
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz"
@@ -4408,10 +4469,20 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+esutils@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.0.0.tgz#8151d358e20c8acc7fb745e7472c0025fe496570"
+  integrity sha512-x/iYH53X3quDwfHRz4y8rn4XcEwwCJeWsul9pF1zldMbGtgOtMNBEOuYWwB1EQlK2LRa1fev3YAgym/RElp5Cg==
+
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+eve@~0.5.1:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/eve/-/eve-0.5.4.tgz#67d080b9725291d7e389e34c26860dd97f1debaa"
+  integrity sha512-aqprQ9MAOh1t66PrHxDFmMXPlgNO6Uv1uqvxmwjprQV50jaQ2RqO7O1neY4PJwC+hMnkyMDphu2AQPOPZdjQog==
 
 eventemitter3@^4.0.0:
   version "4.0.7"
@@ -7631,6 +7702,17 @@ react-app-polyfill@^3.0.0:
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
 
+react-burger-menu@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/react-burger-menu/-/react-burger-menu-3.0.8.tgz#78744db0a576f981aeade4f3f8ee956bc094c107"
+  integrity sha512-pkPHOUKKd5ClLg5OERIZLXtnYCO2Vxvti+BBIIVLNiD2xjCdgfkSt4TZ2IPUQBkYUY/id7Mq56YDgQ16p4kZog==
+  dependencies:
+    browserify-optional "^1.0.0"
+    classnames "^2.2.6"
+    eve "~0.5.1"
+    prop-types "^15.7.2"
+    snapsvg-cjs "0.0.6"
+
 react-dev-utils@^12.0.1:
   version "12.0.1"
   resolved "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz"
@@ -8010,6 +8092,11 @@ resolve.exports@^1.1.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+  integrity sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==
+
 resolve@^1.1.7, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz"
@@ -8306,6 +8393,20 @@ snake-case@^3.0.3:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+snapsvg-cjs@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/snapsvg-cjs/-/snapsvg-cjs-0.0.6.tgz#3b2f56af2573d3d364c3ed5bf8885745f4d2dde1"
+  integrity sha512-7NNvoGrc3BQvWz5rWK1DsD5/Vni4STswz5B3JrBADboQWcN8OBVGjYVJFPT5JkUXb2iVnEflZANhufEpEcTHXw==
+  dependencies:
+    snapsvg "0.5.1"
+
+snapsvg@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/snapsvg/-/snapsvg-0.5.1.tgz#0caf52c79189a290746fc446cc5e863f6bdddfe3"
+  integrity sha512-CjwWYsL7+CCk1vCk9BBKGYS4WJVDfJAOMWU+Zhzf8wf6pAm/xT34wnpaMPAgcgCNkxuU6OkQPPd8wGuRCY9aNw==
+  dependencies:
+    eve "~0.5.1"
+
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz"
@@ -8358,6 +8459,13 @@ source-map@^0.8.0-beta.0:
   integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
   dependencies:
     whatwg-url "^7.0.0"
+
+source-map@~0.1.30:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==
+  dependencies:
+    amdefine ">=0.0.4"
 
 sourcemap-codec@^1.4.8:
   version "1.4.8"
@@ -8753,6 +8861,11 @@ throat@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
+
+through@~2.3.4:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 thunky@^1.0.2:
   version "1.1.0"


### PR DESCRIPTION
【実装したこと】
「バックエンド」
１　ユーザーの一覧を表示するためにusers_controllerを作成しました
２　そのユーザーに関連した投稿を表示するためのuser_comics_controllerを作成しました
３　ユーザーのシーン数表示のためuser_comics_controllerとcomics_controllerにscene_post_countメソッドを追加しました
４　お気に入り数表示のため、favorites_countメソッドを追加しました
「フロントエンド」
１　userのapiオブジェクトとカスタムフックを作成
２　ユーザー一覧を表示するGeneralUser.jsコンポーネントを作成
３　各画面のタイトルの横のアイコンを変更しています
４　レスポンシブ時に、ハンバーガーメニューが表示されるようにreact-burger-menuを導入
５　scene_post_countのapiオブジェクトとカスタムフック作成
６　ユーザー一覧画面とマイページのプロフィールにシーン数を表示
７　favorites_countのapiオブジェクトとカスタムフック作成
８　シーン一覧にお気に入り数を表示
【なぜこの変更をしたか】
「バックエンド」
1,2,3,4　それぞれの機能追加に必要なコントローラだったため作成
「フロントエンド」
1,5,7　react-queryを使用するためカスタムフックを作成し、さらにapiのエンドポイントをオブジェクトにまとめ、可読性の向上に繋げました
２　ユーザー一覧ページを実装することにより、登録しているユーザーの詳細情報を知ることができ、アプリを使いやすくなってもらうため
３　アイコンを少しカラフルなアイコンに変えることにより、デザインを明るくし、ユーザーに視覚的な点でも楽しめるようにしました
４　スマホなどのレイアウトはハンバーガメニューを実装した方がより、デザイン的にも良いと判断したので導入しました。
６　シーン数を表示することで、そのユーザーがどれだけ投稿しているのかが分かり、アクティブユーザーを把握するのに便利です
８　お気に入り数を表示することで、人気があるシーンを知ることができます

以上が変更した点になります。細かいタイポやレイアウト調整などは記載していませんが、気になる点があれば再度調整いたします。