### PR TITLE
メールアドレス変更機能実装とサイト越えトラッキング防止機能への対応

### DIFF
--- a/.github/workflows/mbg.yml
+++ b/.github/workflows/mbg.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
         ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} 'cd MangaBestGram-app &&
-        git pull origin 17_confirm-delete-function:main &&
+        git pull origin 18_change-email-function:main &&
         docker-compose down --rmi all &&
         docker rmi $(docker images -q)
         cd frontend &&

--- a/backend/app/controllers/api/v1/user/users_controller.rb
+++ b/backend/app/controllers/api/v1/user/users_controller.rb
@@ -15,6 +15,6 @@ class Api::V1::User::UsersController < SecuredController
   private
 
   def user_params
-    params.permit(:name, :introduction, :image, :url)
+    params.permit(:name, :introduction, :image, :url, :e_mail)
   end
 end

--- a/backend/db/migrate/20221221153704_add_e_mail_to_users.rb
+++ b/backend/db/migrate/20221221153704_add_e_mail_to_users.rb
@@ -1,0 +1,5 @@
+class AddEMailToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :e_mail, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_09_122658) do
+ActiveRecord::Schema.define(version: 2022_12_21_153704) do
 
   create_table "comics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2022_12_09_122658) do
     t.text "url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "e_mail"
   end
 
   add_foreign_key "comics", "users"

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -28,7 +28,7 @@ const Header = () => {
             </li>
             :
             <li className={header.li}>
-              <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcHome /></span>新規登録/ログイン</button>
+              <button onClick={() => loginWithRedirect({ redirect_url: `${window.location.origin}/mypage` })} className={header["nav-sign-in"]}><span className={header["react-icon"]}><FcHome /></span>新規登録/ログイン</button>
             </li>
           }
         </ul>

--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -32,7 +32,7 @@ const Home = () => {
             </div>
             :
             <div className={home["post-title"]}>
-              <button onClick={() => loginWithRedirect({ redirect_url: window.location.origin })} className={home["post-title-link"]}><span className={home["react-icon"]}><FcHome /></span>ログイン/新規登録</button>
+              <button onClick={() => loginWithRedirect({ redirect_url: `${window.location.origin}/mypage` })} className={home["post-title-link"]}><span className={home["react-icon"]}><FcHome /></span>ログイン/新規登録</button>
             </div>
           }
           </div>

--- a/frontend/app/src/components/model/profile/EmailChange.js
+++ b/frontend/app/src/components/model/profile/EmailChange.js
@@ -1,0 +1,66 @@
+import axios from "axios";
+import { useForm } from "react-hook-form";
+import { useUser } from "../../../hooks/useUser";
+import ReactLoading from "react-loading";
+import { useContext } from "react";
+import form from "../../../css/ui/form.module.css";
+import { FcFeedback, FcHighPriority } from "react-icons/fc";
+import { AuthContext } from "../../../providers/AuthGuard";
+import { useNavigate } from "react-router-dom";
+
+const EmailChange = () => {
+  const navigate = useNavigate();
+  const { user, token } = useContext(AuthContext);
+  const { useGetUser } = useUser();
+  const { data: users, isLoading } = useGetUser();
+
+  const { handleSubmit, register, formState: { errors } } = useForm({
+    criteriaMode: "all"
+  });
+
+  const onSubmit = async (data) => {
+    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/users/${users.id}`, data, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    navigate('/email-change-confirm');
+    window.location.reload();
+  }
+
+  if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+
+  return (
+    <div className={form.wrapper}>
+      <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
+        <div className={form["form-text"]}>
+          <div className={form["form-label"]}>現在のメールアドレス</div>
+          {users.e_mail === null && (
+            <div>{ user.email }</div>
+          )}
+          <div>{ users.e_mail }</div>
+        </div>
+        <div className={form["form-text"]}>
+          <div className={form["form-label"]}>変更するメールアドレス</div>
+          { errors.e_mail && <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>メールアドレスを入力してください</div> }
+          <input
+          className={form["form-input"]}
+          placeholder='メールアドレスを入力してください'
+          {...register('e_mail', {
+            required: true
+          })}
+          />
+        </div>
+        <div className={form["form-text-submit"]}>
+          <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default EmailChange;

--- a/frontend/app/src/components/model/profile/MyProfile.js
+++ b/frontend/app/src/components/model/profile/MyProfile.js
@@ -6,7 +6,8 @@ import ProfileEdit from './ProfileEdit';
 import subMenu from "../../../css/ui/subMenu.module.css";
 import mypage from "../../../css/mypage.module.css";
 import { AiFillHome } from "react-icons/ai";
-import { FcVoicePresentation, FcUnlock } from "react-icons/fc";
+import { FcVoicePresentation, FcUnlock, FcKindle } from "react-icons/fc";
+import EmailChange from './EmailChange';
 
 const MyProfile = () => {
   const [tabIndex, setTabIndex] = useState(0);
@@ -36,6 +37,10 @@ const MyProfile = () => {
               <div>パスワード変更</div>
               <div className={mypage["menu-icon"]}><FcUnlock /></div>
             </Tab>
+            <Tab style={ tabIndex === 2 ? color : null } className={mypage["menu-list-in"]}>
+              <div>メールアドレス変更</div>
+              <div className={mypage["menu-icon"]}><FcKindle /></div>
+            </Tab>
           </TabList>
 
           <TabPanel>
@@ -43,6 +48,9 @@ const MyProfile = () => {
           </TabPanel>
           <TabPanel>
             <PasswordChange />
+          </TabPanel>
+          <TabPanel>
+            <EmailChange />
           </TabPanel>
         </Tabs>
       </div>

--- a/frontend/app/src/components/model/profile/ui/EmailChangeConfirm.js
+++ b/frontend/app/src/components/model/profile/ui/EmailChangeConfirm.js
@@ -1,0 +1,81 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import confirm from "../../../../css/ui/Confirm.module.css";
+import form from "../../../../css/ui/form.module.css";
+import ReactLoading from "react-loading";
+import { FcFeedback } from "react-icons/fc";
+import { useUser } from "../../../../hooks/useUser";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+const EmailChangeConfirm = () => {
+  const navigate = useNavigate();
+  const [ token, setToken ] = useState('');
+  const { useGetUser } = useUser();
+  const { data: users, isLoading } = useGetUser();
+
+  const options = {
+    method: 'POST',
+    url: 'https://dev-mqrxqmfa.us.auth0.com/oauth/token',
+    data: {client_id: process.env.REACT_APP_AUTH0_MANAGEMENT_CLIENT_ID, client_secret : process.env.REACT_APP_AUTH0_MANAGEMENT_CLIENT_SECRET, audience: process.env.REACT_APP_AUTH0_MANAGEMENT_CLIENT_AUDIENCE, grant_type: process.env.REACT_APP_AUTH0_MANAGEMENT_GRANT_TYPE }
+  };
+
+  const getToken = async () => {
+    try {
+      const access_token = await axios(options);
+      setToken(access_token)
+    } catch (e) {
+      console.log(e.message)
+    }
+  };
+
+  useEffect(() => {
+    getToken();
+  }, []);
+
+  const onSubmit = async (data) => {
+    await axios.patch(`https://dev-mqrxqmfa.us.auth0.com/api/v2/users/${users.sub}`, data, {
+      headers: {
+        Authorization: `Bearer ${token.data.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    .catch((error) => {
+      console.error(error.response.data);
+    });
+    alert('メールアドレスが変更されました');
+    navigate(`/my-profile/${users.id}`)
+  }
+
+  const { handleSubmit, register } = useForm({
+  });
+
+  if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+
+  return (
+    <div className={confirm.section}>
+      <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
+        <div className={confirm.content}>
+          <div className={confirm.article}>
+            <div className={confirm['confirm-title']}>以下の内容で登録してもよろしいですか？</div>
+            <div className={confirm["detail-area"]}>
+              <p className={confirm.detail}>メールアドレス</p>
+              <div>{ users.e_mail }</div>
+              <input
+                type='hidden'
+                className={form["form-input"]}
+                defaultValue={ users.e_mail }
+                {...register('email')}
+              />
+            </div>
+            <div className={form["form-text-submit"]}>
+              <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default EmailChangeConfirm;

--- a/frontend/app/src/index.js
+++ b/frontend/app/src/index.js
@@ -15,7 +15,10 @@ root.render(
     domain={domain}
     clientId={clientId}
     audience={audience}
-    redirectUri={window.location.origin}
+    redirectUri={`${window.location.origin}/mypage`}
+    onRedirectCallback={`${window.location.origin}/mypage`}
+    useRefreshTokens={true}
+    cacheLocation='localstorage'
   >
     <App />
   </Auth0Provider>

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -22,3 +22,4 @@ export { default as GeneralUser } from '../components/model/user/GeneralUser';
 export { default as GeneralUserComic } from '../components/model/user/GeneralUserComic';
 export { default as ComicConfirmDelete } from '../components/model/mypage/ui/ComicConfirmDelete';
 export { default as ScenePostConfirmDelete } from '../components/model/scene_post/ui/ScenePostConfirmDelete';
+export { default as EmailChangeConfirm } from '../components/model/profile/ui/EmailChangeConfirm';

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -19,7 +19,8 @@ import {
   GeneralUser,
   GeneralUserComic,
   ComicConfirmDelete,
-  ScenePostConfirmDelete
+  ScenePostConfirmDelete,
+  EmailChangeConfirm
 } from './Pages';
 
 const Routers = () => {
@@ -45,6 +46,7 @@ const Routers = () => {
       <Route path='/general_scene_post/:comic_title/:scene_post_id/comment' element={ <ProtectedRoute component={CommentNew}/> } />
       <Route path='/users' element={ <GeneralUser /> } />
       <Route path='/users/:user_id/comics' element={ <GeneralUserComic /> } />
+      <Route path='/email-change-confirm' element={ <ProtectedRoute component={EmailChangeConfirm}/> } />
     </Routes>
   );
 };


### PR DESCRIPTION
【実装したこと】
「バックエンド」
１　メールアドレスの変更に対応するために自前のDBにもメールアドレスを入れるカラムを追加しました
「フロントエンド」
１　Aurh0のサイト越えトラッキングがONの状態でもログインができるようにするために、リフレッシュトークンローテーションを使用しました。その設定のため、onRedirectCallback, useRefreshTokens, cacheLocation, を追加し、redirectUri先をマイページにリダイレクトされるように変更しました。
２　ユーザーがログインした後のリダイレクト先をマイページになるように変更しました
３　メールアドレスの変更機能を実装しました。確認画面を挟んで、メールアドレスを変更できるロジックです
【なぜこの変更をしたか】
「バックエンド」
１　メールアドレスはAuth0側のメタデータを使用しているが、即時反映がされないので、即時反映したデータを表示するために自前のDBにもメールアドレスを入れるカラムを追加しました。
※あまりスマートな方法ではないかもしれませんが、この方法で実装しています。
「フロントエンド」
１　safariにはデフォルトで設定されている機能なので、この機能をONにしているユーザーがほとんどだと思うので、ログインできないユーザーが出てくるのを防止するため
２　ログイン後にすぐにマイページを表示した方がユーザービリティに長けているから
３　メールアドレスの変更画面で、自前のDB側にメールアドレスを登録し、確認画面でauth0側にメールアドレスを登録できるロジックです。
auth0側のメタデータを反映させるのが一番いい方法ではあるのですが、調べてみたところ、即時反映ができないみたいなので、この方法で実装しています。

以上が変更した点になります。気になる点があれば、修正いたします。