### PR TITLE
各編集画面の画像変更のロジックを別コンポーネントに切り分け

### DIFF
--- a/frontend/app/src/api/user.js
+++ b/frontend/app/src/api/user.js
@@ -15,4 +15,17 @@ export const user = {
     });
     return res.data;
   },
+
+  putUser: async (params, UserId, token) => {
+    await axios
+    .put(`${process.env.REACT_APP_DEV_API_URL}/user/users/${UserId}`, params, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    .catch((error) => {
+      console.error(error.response.data);
+    });
+  }
 }

--- a/frontend/app/src/api/user.js
+++ b/frontend/app/src/api/user.js
@@ -28,4 +28,4 @@ export const user = {
       console.error(error.response.data);
     });
   }
-}
+};

--- a/frontend/app/src/components/model/mypage/ComicEdit.js
+++ b/frontend/app/src/components/model/mypage/ComicEdit.js
@@ -3,40 +3,26 @@ import { useNavigate, useParams, Link } from "react-router-dom";
 import { useComic } from "../../../hooks/useComic";
 import form from "../../../css/ui/form.module.css";
 import subMenu from "../../../css/ui/subMenu.module.css";
-import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import ReactLoading from "react-loading";
 import comicNewGenreJson from "../../../json/comicNewGenre.json";
 import { AiFillHome } from "react-icons/ai";
-import axios from "axios";
-import { AuthContext } from "../../../providers/AuthGuard";
-import { useContext } from "react";
 import { FcReading, FcHighPriority, FcFile, FcPicture, FcFeedback, FcUpLeft } from "react-icons/fc";
 import { BsFillTrashFill } from "react-icons/bs";
-
 
 const ComicEdit = () => {
   const navigate = useNavigate();
   const { comic_id, comic_title } = useParams();
-  const { token } = useContext(AuthContext);
-  
-  const { useShowComic } = useComic();
+
+  const { useShowComic, usePutComic } = useComic();
   const { data: comics, isLoading } = useShowComic(comic_id);
+  const putComic = usePutComic(comic_id);
 
-  const onSubmit = async (data) => {
-    const formData = new FormData();
-    formData.append("title", data.title);
-    formData.append("genre", data.genre);
-    formData.append("image", data.image[0]);
-
-    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/comics/${comic_id}`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
-      console.error(error.res.data);
-    });
+  const onSubmit = (data) => {
+    try {
+      putComic.mutate(data);
+    } catch (error) {
+      console.error(error.response.data);
+    }
     alert(`${comic_title}を編集しました！`);
     navigate("/mypage");
   };
@@ -96,13 +82,7 @@ const ComicEdit = () => {
             </select>
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}><span className={form["react-icon"]}><FcPicture /></span>漫画の画像</div>
-            <input
-              className={form["form-input-image"]}
-              type="file"
-              accept="image/*"
-              {...register("image")}
-            />
+            <Link to={`/comic/${comic_id}/${comic_title}/comic_edit/comic-image-edit`} className={form['image-button']}><span className={form['react-icon']}><FcPicture /></span>画像を変更する</Link>
           </div>
           <div className={form["form-text"]}>
             <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
@@ -111,7 +91,7 @@ const ComicEdit = () => {
             <Link to={`/comic/${comic_id}/${comic_title}/comic_confirm_delete`} className={form['delete-button']}><span className={form['delete-button-icon']}><BsFillTrashFill /></span>削除</Link>
           </div>
           <div className={form["form-text-back"]}>
-            <button onClick={() => navigate('/mypage')} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>マイページへ戻る</button>
+            <button onClick={() => navigate('/mypage')} className={form.back}><span className={form["react-icon"]}><FcUpLeft /></span>マイページへ戻る</button>
           </div>
         </form>
       </div>

--- a/frontend/app/src/components/model/mypage/ComicEdit.js
+++ b/frontend/app/src/components/model/mypage/ComicEdit.js
@@ -77,7 +77,7 @@ const ComicEdit = () => {
             >
               <option>{ comics.genre }</option>
               {comicNewGenreJson.map((genre, index) =>
-                <option key={index} >{ genre.genre }</option>
+                <option key={index}>{ genre.genre }</option>
               )}
             </select>
           </div>

--- a/frontend/app/src/components/model/mypage/Profile.js
+++ b/frontend/app/src/components/model/mypage/Profile.js
@@ -26,7 +26,6 @@ const Profile = () => {
   if(favoriteLoading) return <></>
   if(comicLoading) return <></>
   if(scenePostCountsLoading) return <></>
-  console.log(user)
 
   return (
     <div className={profile.wrapper}>

--- a/frontend/app/src/components/model/mypage/ui/ComicImageEdit.js
+++ b/frontend/app/src/components/model/mypage/ui/ComicImageEdit.js
@@ -1,0 +1,79 @@
+import axios from "axios";
+import { useNavigate, useParams } from "react-router-dom";
+import { useComic } from "../../../../hooks/useComic";
+import ReactLoading from "react-loading";
+import { useForm } from "react-hook-form";
+import form from "../../../../css/ui/form.module.css";
+import subMenu from "../../../../css/ui/subMenu.module.css";
+import { FcPicture, FcFeedback, FcUpLeft, FcHighPriority } from "react-icons/fc";
+import noimage from "../../../../image/default.png";
+import { useContext } from "react";
+import { AuthContext } from "../../../../providers/AuthGuard";
+
+const ComicImageEdit = () => {
+  const navigate = useNavigate();
+  const { comic_id, comic_title } = useParams();
+  const { token } = useContext(AuthContext);
+
+  const { useShowComic } = useComic();
+  const { data: comic, isLoading } = useShowComic(comic_id);
+
+  const onSubmit = async (data) => {
+    const formData = new FormData();
+    formData.append("image", data.image[0]);
+
+    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/comics/${comic_id}`, formData, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    alert(`画像が変更されました！`);
+    navigate("/mypage");
+  };
+
+  const { handleSubmit, register, formState: { errors } } = useForm({
+    criteriaMode: "all"
+  });
+
+  if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
+
+  return (
+    <div className={subMenu.wrapper}>
+      <div className={subMenu.content}>
+        <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
+          <div className={form["form-text"]}>
+            <div className={form["outer-image"]}>
+              <p className={form.detail}><span className={form["react-icon"]}><FcPicture /></span>現在の画像</p>
+              <img className={form.image} src={ comic.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
+            </div>
+            <div className={form["form-text-image"]}>
+              { errors.image &&
+                <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>画像を選択してください</div> 
+              }
+              <input
+                className={form["form-input-image"]}
+                type="file"
+                accept="image/*"
+                {...register("image", {
+                  required: true
+                })}
+              />
+            </div>
+          </div>
+          <div className={form["form-text"]}>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
+          </div>
+          <div className={form["form-text-back"]}>
+            <button onClick={() => navigate(-1)} className={form.back}><span className={form["react-icon"]}><FcUpLeft /></span>{ comic_title }の編集画面に戻る</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ComicImageEdit;

--- a/frontend/app/src/components/model/profile/ProfileEdit.js
+++ b/frontend/app/src/components/model/profile/ProfileEdit.js
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useUser } from "../../../hooks/useUser";
 import { AuthContext } from "../../../providers/AuthGuard";
 import form from "../../../css/ui/form.module.css";
@@ -82,13 +82,7 @@ const ProfileEdit = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}><span className={form["react-icon"]}><FcButtingIn /></span>ユーザーアイコン</div>
-            <input
-              className={form["form-input-image"]}
-              type="file"
-              accept="image/*"
-              {...register("image")}
-            />
+            <Link to={`/my-profile/${user_id}/profile-image-edit`} className={form['image-button']}><span className={form['react-icon']}><FcButtingIn /></span>画像を変更する</Link>
           </div>
           <div className={form["form-text"]}>
             <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>

--- a/frontend/app/src/components/model/profile/ProfileEdit.js
+++ b/frontend/app/src/components/model/profile/ProfileEdit.js
@@ -5,7 +5,6 @@ import form from "../../../css/ui/form.module.css";
 import { FcPortraitMode, FcGraduationCap, FcImageFile, FcFeedback, FcButtingIn, FcUpLeft, FcHighPriority } from "react-icons/fc";
 import ReactLoading from "react-loading";
 import subMenu from "../../../css/ui/subMenu.module.css";
-import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 
 const ProfileEdit = () => {
   const navigate = useNavigate();
@@ -75,7 +74,7 @@ const ProfileEdit = () => {
             <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
           </div>
           <div className={form["form-text-back"]}>
-            <button onClick={() => navigate('/mypage')} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>マイページへ戻る</button>
+            <button onClick={() => navigate('/mypage')} className={form.back}><span className={form["react-icon"]}><FcUpLeft /></span>マイページへ戻る</button>
           </div>
         </form>
       </div>

--- a/frontend/app/src/components/model/profile/ProfileEdit.js
+++ b/frontend/app/src/components/model/profile/ProfileEdit.js
@@ -1,11 +1,8 @@
-import { useContext } from "react";
 import { useForm } from "react-hook-form";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useUser } from "../../../hooks/useUser";
-import { AuthContext } from "../../../providers/AuthGuard";
 import form from "../../../css/ui/form.module.css";
 import { FcPortraitMode, FcGraduationCap, FcImageFile, FcFeedback, FcButtingIn, FcUpLeft, FcHighPriority } from "react-icons/fc";
-import axios from "axios";
 import ReactLoading from "react-loading";
 import subMenu from "../../../css/ui/subMenu.module.css";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
@@ -13,30 +10,20 @@ import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.cs
 const ProfileEdit = () => {
   const navigate = useNavigate();
   const { user_id } = useParams();
-  const { token } = useContext(AuthContext);
 
-  const { useGetUser } = useUser();
+  const { useGetUser, usePutUser } = useUser();
   const { data: user, isLoading } = useGetUser(user_id);
+  const putUser = usePutUser(user_id);
 
   //更新関数
   const onSubmit = async (data) => {
-    const formData = new FormData();
-    formData.append("name", data.name);
-    formData.append("introduction", data.introduction);
-    formData.append("url", data.url);
-    formData.append("image", data.image[0]);
-
-    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/users/${user_id}`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
-      console.error(error.res.data);
-    });
-    alert(`編集しました！`);
-    navigate("/mypage");
+    try {
+      putUser.mutate(data);
+    } catch (error) {
+      console.error(error.response.data);
+    }
+    alert('編集しました！')
+    navigate('/mypage')
   };
 
   const { handleSubmit, register, formState: { errors } } = useForm({

--- a/frontend/app/src/components/model/profile/ui/ProfileImageEdit.js
+++ b/frontend/app/src/components/model/profile/ui/ProfileImageEdit.js
@@ -1,0 +1,78 @@
+import axios from "axios";
+import { useContext } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate, useParams } from "react-router-dom";
+import { useUser } from "../../../../hooks/useUser";
+import { AuthContext } from "../../../../providers/AuthGuard";
+import ReactLoading from "react-loading";
+import subMenu from "../../../../css/ui/subMenu.module.css";
+import form from "../../../../css/ui/form.module.css";
+import { FcPicture, FcFeedback, FcUpLeft, FcHighPriority } from "react-icons/fc";
+
+const ProfileImageEdit = () => {
+  const navigate = useNavigate();
+  const { user_id } = useParams();
+  const { token } = useContext(AuthContext);
+
+  const { useGetUser } = useUser();
+  const { data: user, isLoading } = useGetUser(user_id);
+
+  const onSubmit = async (data) => {
+    const formData = new FormData();
+    formData.append("image", data.image[0]);
+
+    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/users/${user_id}`, formData, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    .catch((error) => {
+      console.error(error.response.data);
+    });
+    alert(`画像が変更されました！`);
+    navigate("/mypage");
+  };
+
+  const { handleSubmit, register, formState: { errors } } = useForm({
+    criteriaMode: "all"
+  });
+
+  if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
+
+  return (
+    <div className={subMenu.wrapper}>
+      <div className={subMenu.content}>
+        <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
+          <div className={form["form-text"]}>
+            <div className={form["profile-outer-image"]}>
+              <p className={form.detail}><span className={form["react-icon"]}><FcPicture /></span>現在の画像</p>
+              <img className={form["profile-image"]} src={ user.image.url } alt='画像' onError={(e) => e.target.src = noimage} />
+            </div>
+            <div className={form["form-text-image"]}>
+              { errors.image &&
+                <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>画像を選択してください</div> 
+              }
+              <input
+                className={form["form-input-image"]}
+                type="file"
+                accept="image/*"
+                {...register("image", {
+                  required: true
+                })}
+              />
+            </div>
+          </div>
+          <div className={form["form-text"]}>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
+          </div>
+          <div className={form["form-text-back"]}>
+            <button onClick={() => navigate(-1)} className={form.back}><span className={form["react-icon"]}><FcUpLeft /></span>{ user.name }の編集画面に戻る</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileImageEdit;

--- a/frontend/app/src/components/model/scene_post/ScenePostEdit.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostEdit.js
@@ -22,7 +22,7 @@ const ScenePostEdit = () => {
     } catch (error) {
       console.error(error.response.data);
     }
-    alert(`${scene_post.scene_title}を編集しました！`)
+    alert(`${scene_post.sub_title}を編集しました！`)
     navigate(`/comic/${comic_id}/${comic_title}`);
   };
 
@@ -100,7 +100,7 @@ const ScenePostEdit = () => {
             >
               <option>{ scene_post.scene_number }話</option>
               {number.map((numbers, index) =>
-                <option key={index} >{ numbers }話</option>
+                <option key={index}>{ numbers }話</option>
               )}
             </select>
           </div>

--- a/frontend/app/src/components/model/scene_post/ScenePostEdit.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostEdit.js
@@ -4,40 +4,25 @@ import ReactLoading from "react-loading";
 import subMenu from "../../../css/ui/subMenu.module.css";
 import { useForm } from "react-hook-form";
 import form from "../../../css/ui/form.module.css";
-import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import { AiFillHome } from "react-icons/ai";
 import { FcFilm, FcHighPriority, FcCalendar, FcKindle, FcPicture, FcFeedback, FcUpLeft, FcContacts, FcNews } from "react-icons/fc";
 import { BsFillTrashFill } from "react-icons/bs";
-import { AuthContext } from "../../../providers/AuthGuard";
-import { useContext } from "react";
-import axios from "axios";
 
 const ScenePostEdit = () => {
   const navigate = useNavigate();
   const { scene_post_id, comic_id, comic_title  } = useParams();
-  const { token } = useContext(AuthContext);
 
-  const { useShowScenePost } = useScenePost();
+  const { useShowScenePost, usePutScenePost } = useScenePost();
   const { data: scene_post, isLoading } = useShowScenePost(scene_post_id);
+  const putScenePost = usePutScenePost(comic_id, scene_post_id);
 
-  const onSubmit = async (data) => {
-    const formData = new FormData();
-    formData.append("scene_title", data.scene_title);
-    formData.append("scene_number", data.scene_number);
-    formData.append("scene_date", data.scene_date);
-    formData.append("scene_content", data.scene_content);
-    formData.append("scene_image", data.scene_image[0]);
-
-    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/scene_posts/${scene_post_id}`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
-      console.error(error.res.data);
-    });
-    alert(`${scene_post.scene_title}を編集しました！`);
+  const onSubmit = (data) => {
+    try {
+      putScenePost.mutate(data);
+    } catch (error) {
+      console.error(error.response.data);
+    }
+    alert(`${scene_post.scene_title}を編集しました！`)
     navigate(`/comic/${comic_id}/${comic_title}`);
   };
 
@@ -89,7 +74,7 @@ const ScenePostEdit = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}><span className={scenePostShow["react-icon"]}><FcNews /></span>シーンの内容</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcNews /></span>シーンの内容</div>
             { errors.scene_title &&
               <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>好きなシーン名が空欄です</div> 
             }
@@ -129,7 +114,7 @@ const ScenePostEdit = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}><span className={scenePostShow["react-icon"]}><FcKindle /></span>シーンの詳細・感想</div>
+            <div className={form["form-label"]}><span className={form["react-icon"]}><FcKindle /></span>シーンの詳細・感想</div>
             <textarea
               rows='10'
               cols='60'
@@ -140,13 +125,7 @@ const ScenePostEdit = () => {
             />
           </div>
           <div className={form["form-text"]}>
-            <div className={form["form-label"]}><span className={form["react-icon"]}><FcPicture /></span>シーンの画像</div>
-            <input
-              className={form["form-input-image"]}
-              type="file"
-              accept="image/*"
-              {...register("scene_image")}
-            />
+            <Link to={`/scene_post/${comic_id}/${comic_title}/${scene_post_id}/scene_post_edit/scene_post_image_edit`} className={form['image-button']}><span className={form['react-icon']}><FcPicture /></span>画像を変更する</Link>
           </div>
           <div className={form["form-text"]}>
             <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
@@ -155,7 +134,7 @@ const ScenePostEdit = () => {
             <Link to={`/scene_post/${comic_id}/${comic_title}/${scene_post_id}/scene_post_confirm_delete`} className={form['delete-button']}><span className={form['delete-button-icon']}><BsFillTrashFill /></span>削除</Link>
           </div>
           <div className={form["form-text-back"]}>
-            <button onClick={() => navigate(`/comic/${comic_id}/${comic_title}`)} className={scenePostShow.back}><span className={form["react-icon"]}><FcUpLeft /></span>シーン一覧へ戻る</button>
+            <button onClick={() => navigate(`/comic/${comic_id}/${comic_title}`)} className={form.back}><span className={form["react-icon"]}><FcUpLeft /></span>シーン一覧へ戻る</button>
           </div>
         </form>
       </div>

--- a/frontend/app/src/components/model/scene_post/ui/ScenePostImageEdit.js
+++ b/frontend/app/src/components/model/scene_post/ui/ScenePostImageEdit.js
@@ -1,0 +1,79 @@
+import axios from "axios";
+import { useContext } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate, useParams } from "react-router-dom";
+import { useScenePost } from "../../../../hooks/useScenePost";
+import { AuthContext } from "../../../../providers/AuthGuard";
+import ReactLoading from "react-loading";
+import subMenu from "../../../../css/ui/subMenu.module.css";
+import form from "../../../../css/ui/form.module.css";
+import noimage from "../../../../image/default.png";
+import { FcPicture, FcFeedback, FcUpLeft, FcHighPriority } from "react-icons/fc";
+
+const ScenePostImageEdit = () => {
+  const navigate = useNavigate();
+  const { scene_post_id, comic_id, comic_title  } = useParams();
+  const { token } = useContext(AuthContext);
+
+  const { useShowScenePost } = useScenePost();
+  const { data: scene_post, isLoading } = useShowScenePost(scene_post_id);
+
+  const onSubmit = async (data) => {
+    const formData = new FormData();
+    formData.append("scene_image", data.scene_image[0]);
+
+    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/scene_posts/${scene_post_id}`, formData, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    .catch((error) => {
+      console.error(error.res.data);
+    });
+    alert(`画像が変更されました！`);
+    navigate(`/comic/${comic_id}/${comic_title}`);
+  };
+
+  const { handleSubmit, register, formState: { errors } } = useForm({
+    criteriaMode: "all"
+  });
+
+  if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
+
+  return (
+    <div className={subMenu.wrapper}>
+      <div className={subMenu.content}>
+        <form onSubmit={handleSubmit(onSubmit)} className={form.form}>
+          <div className={form["form-text"]}>
+            <div className={form["outer-image"]}>
+              <p className={form.detail}><span className={form["react-icon"]}><FcPicture /></span>現在の画像</p>
+              <img className={form.image} src={ scene_post.scene_image.url } alt='画像' onError={(e) => e.target.src = noimage} />
+            </div>
+            <div className={form["form-text-image"]}>
+              { errors.scene_image &&
+                <div className={form.errors}><span className={form["react-icon"]}><FcHighPriority /></span>画像を選択してください</div> 
+              }
+              <input
+                className={form["form-input-image"]}
+                type="file"
+                accept="image/*"
+                {...register("scene_image", {
+                  required: true
+                })}
+              />
+            </div>
+          </div>
+          <div className={form["form-text"]}>
+            <button className={form["form-submit"]} type="submit"><span className={form["react-icon"]}><FcFeedback /></span>この内容で登録する</button>
+          </div>
+          <div className={form["form-text-back"]}>
+            <button onClick={() => navigate(-1)} className={form.back}><span className={form["react-icon"]}><FcUpLeft /></span>{ scene_post.sub_title }の編集画面に戻る</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ScenePostImageEdit;

--- a/frontend/app/src/css/ui/form.module.css
+++ b/frontend/app/src/css/ui/form.module.css
@@ -42,6 +42,7 @@
   font-size: 20px;
   margin-bottom: 10px;
   margin-top: 20px;
+  font-weight: bold;
 }
 
 .form-input {
@@ -49,6 +50,10 @@
   padding: 12px 0px;
   width: 50%;
   font: inherit;
+}
+
+.form-text-image {
+  margin-top: 100px;
 }
 
 .form-input-image {
@@ -75,6 +80,37 @@
 }
 
 .form-submit:hover {
+  opacity: 0.5;
+}
+
+.back {
+  border: 2px solid #a9a9a9;
+  border-radius: 5px;
+  box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+  font-size: 15px;
+  font-weight: 700;
+  padding: 14px 8px;
+  background-color: #a9a9a9;
+  color: white;
+}
+
+.back:hover {
+  opacity: 0.5;
+}
+
+.image-button {
+  text-decoration: none;
+  background-color: #66cdaa;
+  color: white;
+  font-weight: bold;
+  border: none;
+  border-radius: 5px;
+  padding: 10px 20px;
+  font-size: 15px;
+  box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+}
+
+.image-button:hover {
   opacity: 0.5;
 }
 
@@ -105,6 +141,26 @@
   font-size: 16px;
   vertical-align: -3px;
   margin-right: 3px;
+}
+
+.outer-image {
+  margin: 0 auto;
+  height: 200px;
+  width: 200px;
+}
+
+.image {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
+}
+
+.detail {
+  text-align: center;
+  color: #ff8c00;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  font-weight: bold;
 }
 
 @media screen and (min-width: 541px) and (max-width: 1024px) {

--- a/frontend/app/src/css/ui/form.module.css
+++ b/frontend/app/src/css/ui/form.module.css
@@ -155,6 +155,20 @@
   object-fit: contain;
 }
 
+.profile-outer-image {
+  margin: 0 auto;
+  height: 100px;
+  width: 100px;
+  border-radius: 100px;
+}
+
+.profile-image {
+  margin: 0 auto;
+  height: 100px;
+  width: 100px;
+  border-radius: 100px;
+}
+
 .detail {
   text-align: center;
   color: #ff8c00;

--- a/frontend/app/src/hooks/useUser.js
+++ b/frontend/app/src/hooks/useUser.js
@@ -1,5 +1,5 @@
 import { useContext } from "react"
-import { useQuery } from "react-query";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 import { user } from "../api/user";
 import { AuthContext } from "../providers/AuthGuard"
 
@@ -15,5 +15,30 @@ export const useUser = () => {
       retry: false,
     });
   };
-  return { useGetUser };
+
+  const usePutUser = (UserId) => {
+    const queryClient = useQueryClient();
+    const queryKey = 'user';
+
+    return useMutation(
+      async (params) => {
+        return await user.putUser(
+          params,
+          UserId,
+          token || ''
+        );
+      },
+      {
+        onError: (err, _, context) => {
+          queryClient.setQueryData(queryKey, context);
+
+          console.warn(err);
+        },
+        onSettled: () => {
+          queryClient.invalidateQueries(queryKey);
+        },
+      }
+    );
+  };
+  return { useGetUser, usePutUser };
 };

--- a/frontend/app/src/hooks/useUser.js
+++ b/frontend/app/src/hooks/useUser.js
@@ -40,5 +40,6 @@ export const useUser = () => {
       }
     );
   };
+
   return { useGetUser, usePutUser };
 };

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -24,3 +24,4 @@ export { default as ComicConfirmDelete } from '../components/model/mypage/ui/Com
 export { default as ScenePostConfirmDelete } from '../components/model/scene_post/ui/ScenePostConfirmDelete';
 export { default as EmailChangeConfirm } from '../components/model/profile/ui/EmailChangeConfirm';
 export { default as ComicImageEdit } from '../components/model/mypage/ui/ComicImageEdit';
+export { default as ScenePostImageEdit } from '../components/model/scene_post/ui/ScenePostImageEdit';

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -23,3 +23,4 @@ export { default as GeneralUserComic } from '../components/model/user/GeneralUse
 export { default as ComicConfirmDelete } from '../components/model/mypage/ui/ComicConfirmDelete';
 export { default as ScenePostConfirmDelete } from '../components/model/scene_post/ui/ScenePostConfirmDelete';
 export { default as EmailChangeConfirm } from '../components/model/profile/ui/EmailChangeConfirm';
+export { default as ComicImageEdit } from '../components/model/mypage/ui/ComicImageEdit';

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -25,3 +25,4 @@ export { default as ScenePostConfirmDelete } from '../components/model/scene_pos
 export { default as EmailChangeConfirm } from '../components/model/profile/ui/EmailChangeConfirm';
 export { default as ComicImageEdit } from '../components/model/mypage/ui/ComicImageEdit';
 export { default as ScenePostImageEdit } from '../components/model/scene_post/ui/ScenePostImageEdit';
+export { default as ProfileImageEdit } from '../components/model/profile/ui/ProfileImageEdit';

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -11,6 +11,7 @@ import {
   ComicImageEdit,
   ScenePostShow,
   ScenePostEdit,
+  ScenePostImageEdit,
   GeneralScenePost,
   GeneralComic,
   GeneralScenePostShow,
@@ -35,6 +36,7 @@ const Routers = () => {
       <Route path='/comic/:comic_id/:comic_title/scene_post_new' element={ <ProtectedRoute component={ScenePostNew}/> } />
       <Route path='/scene_post/:comic_title/:scene_post_id' element={ <ProtectedRoute component={ScenePostShow}/> } />
       <Route path='/scene_post/:comic_id/:comic_title/:scene_post_id/scene_post_edit' element={ <ProtectedRoute component={ScenePostEdit}/> } />
+      <Route path='/scene_post/:comic_id/:comic_title/:scene_post_id/scene_post_edit/scene_post_image_edit' element={ <ProtectedRoute component={ScenePostImageEdit}/> } />
       <Route path='/scene_post/:comic_id/:comic_title/:scene_post_id/scene_post_confirm_delete' element={ <ProtectedRoute component={ScenePostConfirmDelete}/> } />
       <Route path='/comic/:comic_id/:comic_title/comic_edit' element={ <ProtectedRoute component={ComicEdit}/> } />
       <Route path='/comic/:comic_id/:comic_title/comic_edit/comic-image-edit' element={ <ProtectedRoute component={ComicImageEdit}/> } />

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -2,15 +2,16 @@ import { Routes, Route } from 'react-router-dom';
 import ProtectedRoute from '../providers/protectedRoute';
 import {
   Home,
-  TermsOfService, 
-  PrivacyPolicy, 
+  TermsOfService,
+  PrivacyPolicy,
   MyPage,
-  ScenePost, 
-  ScenePostNew, 
-  ComicEdit, 
-  ScenePostShow, 
-  ScenePostEdit, 
-  GeneralScenePost, 
+  ScenePost,
+  ScenePostNew,
+  ComicEdit,
+  ComicImageEdit,
+  ScenePostShow,
+  ScenePostEdit,
+  GeneralScenePost,
   GeneralComic,
   GeneralScenePostShow,
   Page404,
@@ -36,6 +37,7 @@ const Routers = () => {
       <Route path='/scene_post/:comic_id/:comic_title/:scene_post_id/scene_post_edit' element={ <ProtectedRoute component={ScenePostEdit}/> } />
       <Route path='/scene_post/:comic_id/:comic_title/:scene_post_id/scene_post_confirm_delete' element={ <ProtectedRoute component={ScenePostConfirmDelete}/> } />
       <Route path='/comic/:comic_id/:comic_title/comic_edit' element={ <ProtectedRoute component={ComicEdit}/> } />
+      <Route path='/comic/:comic_id/:comic_title/comic_edit/comic-image-edit' element={ <ProtectedRoute component={ComicImageEdit}/> } />
       <Route path='/comic/:comic_id/:comic_title/comic_confirm_delete' element={ <ProtectedRoute component={ComicConfirmDelete}/> } />
       <Route path='/general_scene_post/:comic_title/:comic_id' element={ <GeneralScenePost /> } />
       <Route path='/general_scene_post/:comic_title/general_scene_post_show/:scene_post_id/' element={ <GeneralScenePostShow /> } />

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -17,6 +17,7 @@ import {
   GeneralScenePostShow,
   Page404,
   MyProfile,
+  ProfileImageEdit,
   CommentNew,
   GeneralUser,
   GeneralUserComic,
@@ -42,11 +43,11 @@ const Routers = () => {
       <Route path='/comic/:comic_id/:comic_title/comic_edit/comic-image-edit' element={ <ProtectedRoute component={ComicImageEdit}/> } />
       <Route path='/comic/:comic_id/:comic_title/comic_confirm_delete' element={ <ProtectedRoute component={ComicConfirmDelete}/> } />
       <Route path='/general_scene_post/:comic_title/:comic_id' element={ <GeneralScenePost /> } />
-      <Route path='/general_scene_post/:comic_title/general_scene_post_show/:scene_post_id/' element={ <GeneralScenePostShow /> } />
-      <Route path='/general_scene_post/general_scene_post_show/:scene_post_id/' element={ <GeneralScenePostShow /> } />
+      <Route path='/general_scene_post/:comic_title/general_scene_post_show/:scene_post_id' element={ <GeneralScenePostShow /> } />
       <Route path='/comic' element={ <GeneralComic /> } />
       <Route path='*' element={ <Page404 /> } />
       <Route path='/my-profile/:user_id' element={ <ProtectedRoute component={MyProfile}/> } />
+      <Route path='/my-profile/:user_id/profile-image-edit' element={ <ProtectedRoute component={ProfileImageEdit}/> } />
       <Route path='/general_scene_post/:comic_title/:scene_post_id/comment' element={ <ProtectedRoute component={CommentNew}/> } />
       <Route path='/users' element={ <GeneralUser /> } />
       <Route path='/users/:user_id/comics' element={ <GeneralUserComic /> } />


### PR DESCRIPTION
【実装したこと】
「フロントエンド」
１　ComicとScenePostとProfileの編集画面の画像変更のロジックを別コンポーネントに変更しました。
２　画像以外の編集のロジックをreact-queryを用いての実装に変更しました。
【なぜこの変更をしたか】
「フロントエンド」
１　画像の変更時に、同じコンポーネントにロジックを記載してしまうと、編集時に画像を選択しないで送信をした場合、保存してある画像が消えてしまうので、それを防止するために別コンポーネントに分けました。
２　画像以外の送信は、formDataに変換しなくてもいいので、react-queryを用いての実装に変更しました。

以上が変更した点になります。気になる点があれば修正いたします。