### PR TITLE
CarrierWaveの拡張子,GithubActionsのブランチ,シーンの詳細画面のサブメニューの表示を修正

### DIFF
--- a/.github/workflows/mbg.yml
+++ b/.github/workflows/mbg.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - master
 
 jobs:
   setup_and_test_execution:

--- a/backend/app/uploaders/file_uploader.rb
+++ b/backend/app/uploaders/file_uploader.rb
@@ -20,7 +20,7 @@ class FileUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w(jpg jpeg png)
+    %w(jpg jpeg png webp)
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/frontend/app/src/components/model/general/GeneralScenePostShow.js
+++ b/frontend/app/src/components/model/general/GeneralScenePostShow.js
@@ -32,7 +32,7 @@ const GeneralScenePostShow = () => {
             <Link to={`/general_scene_post/${scene_post.data.attributes.scenePostComicTitle}/${scene_post.data.attributes.comicId}`} className={subMenu["home-link"]}><span>&nbsp;/&nbsp;{ scene_post.data.attributes.scenePostComicTitle }</span></Link>
           </span>
           <span className={subMenu["scene-title"]}>
-          /&nbsp;{ scene_post.data.attributes.sceneTitle }の詳細画面
+          /&nbsp;{ scene_post.data.attributes.subTitle }の詳細画面
           </span>
         </div>
       </div>


### PR DESCRIPTION
【実装したこと】
「バックエンド」
１　CarrierWaveのアップロードを許可する拡張子にwebpを追加しました
２　GithubActionsが発動するブランチ名にmasterブランチを追加しました
「フロントエンド」
１　シーンの詳細画面のサブメニューの表示がシーンの内容が表示されるようになっていたので、サブタイトルが表示されるように修正しました
【なぜこの変更をしたのか】
「バックエンド」
１　webpの拡張子の画像ファイルも多いので、アップロードできないのはユーザーにとって不親切です
２　masterブランチは全てのチェックを通過した最終的なブランチなので、このブランチの内容を本番環境に反映させるためです
「フロントエンド」
１　シーンの内容ではなく、そのシーンの要約であるサブタイトルを表示させるほうがユーザービリティに優れているため

以上が変更した点になります。気になる点があれば、再度修正いたします。