### PR TITLE
シーンの詳細ページのシーンの詳細・感想に入力されたデータの改行が反映されるように機能追加

### DIFF
--- a/frontend/app/src/components/model/general/GeneralScenePostShow.js
+++ b/frontend/app/src/components/model/general/GeneralScenePostShow.js
@@ -8,7 +8,7 @@ import { FcReading, FcFilm, FcKindle, FcSms, FcCalendar, FcContacts, FcNews, FcU
 import scenery from "../../../image/scenery.png";
 import Comment from "../comment/Comment";
 import { AuthContext } from "../../../providers/AuthGuard";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import moment from 'moment';
 
 const GeneralScenePostShow = () => {
@@ -20,6 +20,15 @@ const GeneralScenePostShow = () => {
   const { data: scene_post, isLoading} = useShowGeneralScenePost(scene_post_id);
 
   if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
+
+  const newLines = scene_post.data.attributes.sceneContent.split('\n').map((newLine, index) => {
+    return (
+      <React.Fragment key={index}>
+        { newLine }
+        <br />
+      </React.Fragment>
+    );
+  });
 
   return (
     <div className={subMenu.wrapper}>
@@ -73,7 +82,7 @@ const GeneralScenePostShow = () => {
               { scene_post.data.attributes.sceneContent == null && (
                 <span>シーンの詳細・感想がありません</span>
               ) }
-              <div>{ scene_post.data.attributes.sceneContent }</div>
+              <div>{newLines}</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
               <button onClick={() => navigate(`/general_scene_post/${scene_post.data.attributes.scenePostComicTitle}/${scene_post.data.attributes.comicId}`)} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>シーン一覧へ戻る</button>

--- a/frontend/app/src/components/model/scene_post/ScenePostShow.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostShow.js
@@ -8,6 +8,7 @@ import { FcReading, FcFilm, FcKindle, FcSms, FcCalendar, FcContacts, FcNews, FcU
 import scenery from "../../../image/scenery.png";
 import moment from 'moment';
 import Comment from "../comment/Comment";
+import React from "react";
 
 const ScenePostShow = () => {
   const navigate = useNavigate();
@@ -17,6 +18,15 @@ const ScenePostShow = () => {
   const { data: scene_post, isLoading } = useShowScenePost(scene_post_id);
 
   if(isLoading) return <ReactLoading type="spin" color="blue" className='loading' />
+
+  const newLines = scene_post.scene_content.split('\n').map((newLine, index) => {
+    return (
+      <React.Fragment key={index}>
+        { newLine }
+        <br />
+      </React.Fragment>
+    );
+  });
 
   return (
     <div className={subMenu.wrapper}>
@@ -70,7 +80,7 @@ const ScenePostShow = () => {
               { scene_post.scene_content == null && (
                 <span>シーンの詳細・感想がありません</span>
               ) }
-              <div>{ scene_post.scene_content }</div>
+              <div>{ newLines }</div>
             </div>
             <div className={scenePostShow["detail-area"]}>
               <button onClick={() => navigate(-1)} className={scenePostShow.back}><span className={scenePostShow["react-icon"]}><FcUpLeft /></span>シーン一覧へ戻る</button>


### PR DESCRIPTION
【実装したこと】
「フロントエンド」
１　シーンの詳細ページのシーンの詳細・感想に入力されたデータの改行が反映されるように機能追加しました。

【なぜこの実装をしたか】
１　ユーザーが投稿をする際に、改行がないと、文章が閲覧しづらくなり、ユーザービリティに欠けるので変更しました。

以上が変更した点になります。気になる点があれば、再度調整いたします。