### PR TITLE
Sort機能の並び順がID順に正常に並んでいなかったので修正しました

### DIFF
--- a/frontend/app/src/components/model/general/GeneralComic.js
+++ b/frontend/app/src/components/model/general/GeneralComic.js
@@ -40,11 +40,11 @@ const GeneralComic = () => {
         if (a === b) {
           return 0;
         }
-        if (a > b) {
-          return 1 * sort.order;
+        if (a > b ? -1 : 1) {
+          return 1 ? -1 : 1 * sort.order;
         }
-        if (a < b) {
-          return -1 * sort.order;
+        if (a < b ? -1 : 1) {
+          return -1 ? -1 : 1 * sort.order;
         }
       });
     }

--- a/frontend/app/src/components/model/general/GeneralScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralScenePost.js
@@ -54,11 +54,11 @@ const GeneralScenePost = () => {
         if (a === b) {
           return 0;
         }
-        if (a > b) {
-          return 1 * sort.order;
+        if (a > b ? -1 : 1) {
+          return 1 ? -1 : 1 * sort.order;
         }
         if (a < b) {
-          return -1 * sort.order;
+          return -1 ? -1 : 1 * sort.order;
         }
       });
     }
@@ -86,11 +86,11 @@ const GeneralScenePost = () => {
         if (a === b) {
           return 0;
         }
-        if (a > b) {
-          return 1 * generalSort.order;
+        if (a > b ? -1 : 1) {
+          return 1 ? -1 : 1 * generalSort.order;
         }
-        if (a < b) {
-          return -1 * generalSort.order;
+        if (a < b ? -1 : 1) {
+          return -1 ? -1 : 1 * generalSort.order;
         }
       });
     }

--- a/frontend/app/src/components/model/mypage/ComicPost.js
+++ b/frontend/app/src/components/model/mypage/ComicPost.js
@@ -36,11 +36,11 @@ const ComicPost = () => {
         if (a === b) {
           return 0;
         }
-        if (a > b) {
-          return 1 * sort.order;
+        if (a > b ? -1 : 1) {
+          return 1 ? -1 : 1 * sort.order;
         }
-        if (a < b) {
-          return -1 * sort.order;
+        if (a < b ? -1 : 1) {
+          return -1 ? -1 : 1 * sort.order;
         }
       });
     }
@@ -63,7 +63,7 @@ const ComicPost = () => {
   return (
     <div className={comicPost.wrapper}>
       <div className={comicPost.count}>【投稿数】&nbsp;{comics.length}件</div>
-      <button className={sort.key === 'updated_at' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('updated_at')}>並び替え</button>
+      <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え</button>
       <div className={comicPost.search}>
         <span className={comicPost["fc-search"]}><FcSearch /></span>
         <input

--- a/frontend/app/src/components/model/scene_post/ScenePost.js
+++ b/frontend/app/src/components/model/scene_post/ScenePost.js
@@ -38,11 +38,11 @@ const ScenePost = () => {
         if (a === b) {
           return 0;
         }
-        if (a > b) {
-          return 1 * sort.order;
+        if (a > b ? -1 : 1) {
+          return 1 ? -1 : 1 * sort.order;
         }
-        if (a < b) {
-          return -1 * sort.order;
+        if (a < b ? -1 : 1) {
+          return -1 ? -1 : 1 * sort.order;
         }
       });
     }
@@ -93,7 +93,7 @@ const ScenePost = () => {
       <button className={scenePost.link}>
         <Link to={`/comic/${comic_id}/${comic_title}/scene_post_new`}><span className={scenePost["react-icon"]}><FcAddImage /></span>新規のシーンを投稿する</Link>
       </button>
-      { data.length === 0 && (
+      { sortedData.length === 0 && (
         <div className={scenePost["detail-result"]}>検索結果がありません</div>
       ) }
       <div className={scenePost["main-content"]}>


### PR DESCRIPTION
【実装したこと】
「フロントエンド」
１　投稿を古い順と新しい順に切り替えることができる機能が、ID順で切り替えられるように実装していたが、数字が2桁を超えると、正常に並ばないバグが発生していた。
なので、ID順に正常に並ぶように修正しました。

以上が実装した点になります。気になる点があれば再度修正いたします。