### PR TITLE
各投稿一覧にreact-queryのキャッシュを使用することで、表示パフォーマンスを高めました

### DIFF
--- a/frontend/app/src/api/comic.js
+++ b/frontend/app/src/api/comic.js
@@ -35,7 +35,7 @@ export const comic = {
     .put(`${process.env.REACT_APP_DEV_API_URL}/user/comics/${comicId}`, params, {
       headers: {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
+        'Content-Type': 'multipart/form-data',
       },
     })
     .catch((error) => {

--- a/frontend/app/src/api/comic.js
+++ b/frontend/app/src/api/comic.js
@@ -21,7 +21,7 @@ export const comic = {
     .post(`${process.env.REACT_APP_DEV_API_URL}/user/comics`, params, {
       headers: {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
+        'Content-Type': 'multipart/form-data',
       },
     })
     .catch((error) => {

--- a/frontend/app/src/api/scenePost.js
+++ b/frontend/app/src/api/scenePost.js
@@ -22,7 +22,7 @@ export const scenePost = {
     .post(`${process.env.REACT_APP_DEV_API_URL}/user/comics/${comicId}/scene_posts`, params, {
       headers: {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
+        'Content-Type': 'multipart/form-data',
       },
     })
     .catch((error) => {
@@ -51,7 +51,7 @@ export const scenePost = {
     .put(`${process.env.REACT_APP_DEV_API_URL}/user/scene_posts/${scenePostId}`, params, {
       headers: {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
+        'Content-Type': 'multipart/form-data',
       },
     })
     .catch((error) => {

--- a/frontend/app/src/api/user.js
+++ b/frontend/app/src/api/user.js
@@ -21,7 +21,7 @@ export const user = {
     .put(`${process.env.REACT_APP_DEV_API_URL}/user/users/${UserId}`, params, {
       headers: {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
+        'Content-Type': 'multipart/form-data',
       },
     })
     .catch((error) => {

--- a/frontend/app/src/components/model/mypage/ComicNew.js
+++ b/frontend/app/src/components/model/mypage/ComicNew.js
@@ -26,7 +26,7 @@ const ComicNew = () => {
       console.error(error.response.data);
     }
     alert("新規登録が完了しました！");
-    navigate("/");
+    navigate("/mypage");
   };
 
   return (

--- a/frontend/app/src/components/model/mypage/ComicNew.js
+++ b/frontend/app/src/components/model/mypage/ComicNew.js
@@ -2,14 +2,13 @@ import { useNavigate } from "react-router-dom";
 import form from "../../../css/ui/form.module.css";
 import { useForm } from 'react-hook-form';
 import comicNewGenreJson from "../../../json/comicNewGenre.json";
-import { useContext } from "react";
-import axios from "axios";
-import { AuthContext } from "../../../providers/AuthGuard";
 import { FcFeedback, FcReading, FcFile, FcHighPriority, FcPicture } from "react-icons/fc";
+import { useComic } from "../../../hooks/useComic";
 
 const ComicNew = () => {
   const navigate = useNavigate();
-  const { token } = useContext(AuthContext);
+  const { useCreateComic } = useComic();
+  const createComic = useCreateComic();
 
   const { handleSubmit, register, formState: { errors } } = useForm({
     criteriaMode: "all"
@@ -21,15 +20,11 @@ const ComicNew = () => {
     formData.append("title", data.title);
     formData.append("genre", data.genre);
 
-    await axios.post(`${process.env.REACT_APP_DEV_API_URL}/user/comics`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
+    try {
+      createComic.mutate(formData);
+    } catch (error) {
       console.error(error.response.data);
-    });
+    }
     alert("新規登録が完了しました！");
     navigate("/");
   };

--- a/frontend/app/src/components/model/mypage/favorite/ui/FavoriteCard.js
+++ b/frontend/app/src/components/model/mypage/favorite/ui/FavoriteCard.js
@@ -4,7 +4,6 @@ import scenery from "../../../../../image/scenery.png";
 import generalScenePost from '../../../../../css/model/general/generalScenePost.module.css';
 import { FcFilm, FcContacts, FcSms, FcMms, FcCalendar } from "react-icons/fc";
 import { useGeneralComment } from "../../../../../hooks/useGeneralComment";
-import ReactLoading from "react-loading";
 import moment from 'moment';
 import { UserInformationName } from "../../../../ui/UserInformationDisplay";
 
@@ -21,7 +20,7 @@ const FavoriteCard = ({
   const { useGetGeneralComment } = useGeneralComment();
 
   const { data: generalComments, isLoading } = useGetGeneralComment(Id);
-  if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  if(isLoading) return <></>
 
   return (
     <div className={generalScenePost.content}>

--- a/frontend/app/src/components/model/mypage/ui/ComicImageEdit.js
+++ b/frontend/app/src/components/model/mypage/ui/ComicImageEdit.js
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { useNavigate, useParams } from "react-router-dom";
 import { useComic } from "../../../../hooks/useComic";
 import ReactLoading from "react-loading";
@@ -7,30 +6,24 @@ import form from "../../../../css/ui/form.module.css";
 import subMenu from "../../../../css/ui/subMenu.module.css";
 import { FcPicture, FcFeedback, FcUpLeft, FcHighPriority } from "react-icons/fc";
 import scenery from "../../../../image/scenery.png";
-import { useContext } from "react";
-import { AuthContext } from "../../../../providers/AuthGuard";
 
 const ComicImageEdit = () => {
   const navigate = useNavigate();
   const { comic_id, comic_title } = useParams();
-  const { token } = useContext(AuthContext);
 
-  const { useShowComic } = useComic();
+  const { useShowComic, usePutComic } = useComic();
   const { data: comic, isLoading } = useShowComic(comic_id);
+  const putComic = usePutComic(comic_id);
 
   const onSubmit = async (data) => {
     const formData = new FormData();
     formData.append("image", data.image[0]);
 
-    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/comics/${comic_id}`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
-      console.error(error.res.data);
-    });
+    try {
+      putComic.mutate(formData);
+    } catch (error) {
+      console.error(error.response.data);
+    }
     alert(`画像が変更されました！`);
     navigate("/mypage");
   };

--- a/frontend/app/src/components/model/profile/ui/ProfileImageEdit.js
+++ b/frontend/app/src/components/model/profile/ui/ProfileImageEdit.js
@@ -1,9 +1,6 @@
-import axios from "axios";
-import { useContext } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { useUser } from "../../../../hooks/useUser";
-import { AuthContext } from "../../../../providers/AuthGuard";
 import ReactLoading from "react-loading";
 import subMenu from "../../../../css/ui/subMenu.module.css";
 import form from "../../../../css/ui/form.module.css";
@@ -13,24 +10,20 @@ import noimage from "../../../../image/default.png";
 const ProfileImageEdit = () => {
   const navigate = useNavigate();
   const { user_id } = useParams();
-  const { token } = useContext(AuthContext);
 
-  const { useGetUser } = useUser();
+  const { useGetUser, usePutUser } = useUser();
   const { data: user, isLoading } = useGetUser(user_id);
+  const putUser = usePutUser(user_id);
 
   const onSubmit = async (data) => {
     const formData = new FormData();
     formData.append("image", data.image[0]);
 
-    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/users/${user_id}`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
+    try {
+      putUser.mutate(formData);
+    } catch (error) {
       console.error(error.response.data);
-    });
+    }
     alert(`画像が変更されました！`);
     navigate("/mypage");
   };

--- a/frontend/app/src/components/model/scene_post/ScenePost.js
+++ b/frontend/app/src/components/model/scene_post/ScenePost.js
@@ -77,7 +77,7 @@ const ScenePost = () => {
           </span>
         </div>
       </div>
-      <div className={scenePost.count}>【投稿数】&nbsp;{scene_posts.length}件</div>
+      <div className={scenePost.count}>【投稿数】&nbsp;{data.length}件</div>
       <div className={scenePost.sort}>
         <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え</button>
       </div>

--- a/frontend/app/src/components/model/scene_post/ScenePostNew.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostNew.js
@@ -4,15 +4,15 @@ import form from '../../../css/ui/form.module.css';
 import subMenu from "../../../css/ui/subMenu.module.css";
 import scenePostShow from "../../../css/model/scene_post/scenePostShow.module.css";
 import { AiFillHome } from "react-icons/ai";
-import { AuthContext } from "../../../providers/AuthGuard";
-import { useContext } from "react";
-import axios from "axios";
 import { FcFilm, FcHighPriority, FcContacts, FcCalendar, FcKindle, FcPicture, FcFeedback, FcUpLeft, FcNews } from "react-icons/fc";
+import { useScenePost } from "../../../hooks/useScenePost";
 
 const ScenePostNew = () => {
   const { comic_id, comic_title } = useParams();
   const navigate = useNavigate();
-  const { token } = useContext(AuthContext);
+
+  const { useCreateScenePost } = useScenePost();
+  const createScenePost = useCreateScenePost(comic_id);
 
   const { handleSubmit, register, formState: { errors } } = useForm({
     criteriaMode: "all"
@@ -28,18 +28,13 @@ const ScenePostNew = () => {
     formData.append("scene_image", data.scene_image[0]);
     formData.append("sub_title", data.sub_title);
 
-    await axios.post(`${process.env.REACT_APP_DEV_API_URL}/user/comics/${comic_id}/scene_posts`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
-      console.error(error.res.data);
-    });
+    try {
+      createScenePost.mutate(formData);
+    } catch (error) {
+      console.error(error.response.data);
+    }
     alert("新規登録が完了しました！");
     navigate("/mypage");
-    console.log(data)
   };
 
   //プルダウンリスト

--- a/frontend/app/src/components/model/scene_post/ui/ScenePostImageEdit.js
+++ b/frontend/app/src/components/model/scene_post/ui/ScenePostImageEdit.js
@@ -1,9 +1,6 @@
-import axios from "axios";
-import { useContext } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { useScenePost } from "../../../../hooks/useScenePost";
-import { AuthContext } from "../../../../providers/AuthGuard";
 import ReactLoading from "react-loading";
 import subMenu from "../../../../css/ui/subMenu.module.css";
 import form from "../../../../css/ui/form.module.css";
@@ -13,24 +10,20 @@ import { FcPicture, FcFeedback, FcUpLeft, FcHighPriority } from "react-icons/fc"
 const ScenePostImageEdit = () => {
   const navigate = useNavigate();
   const { scene_post_id, comic_id, comic_title  } = useParams();
-  const { token } = useContext(AuthContext);
 
-  const { useShowScenePost } = useScenePost();
+  const { useShowScenePost, usePutScenePost } = useScenePost();
   const { data: scene_post, isLoading } = useShowScenePost(scene_post_id);
+  const putScenePost = usePutScenePost(comic_id, scene_post_id);
 
   const onSubmit = async (data) => {
     const formData = new FormData();
     formData.append("scene_image", data.scene_image[0]);
 
-    await axios.put(`${process.env.REACT_APP_DEV_API_URL}/user/scene_posts/${scene_post_id}`, formData, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .catch((error) => {
-      console.error(error.res.data);
-    });
+    try {
+      putScenePost.mutate(formData);
+    } catch (error) {
+      console.error(error.response.data);
+    }
     alert(`画像が変更されました！`);
     navigate(`/comic/${comic_id}/${comic_title}`);
   };

--- a/frontend/app/src/hooks/useComic.js
+++ b/frontend/app/src/hooks/useComic.js
@@ -79,7 +79,7 @@ export const useComic = () => {
       ),
       enabled: !!comicId,
       staleTime: 30000000,
-      cacheTime: 30000000,
+      cacheTime: 0,
     });
   };
 

--- a/frontend/app/src/hooks/useComic.js
+++ b/frontend/app/src/hooks/useComic.js
@@ -10,8 +10,8 @@ export const useComic = () => {
     return useQuery({
       queryKey: 'comic',
       queryFn: () => comic.getComic(token),
-      staleTime: 300000,
-      cacheTime: 0,
+      staleTime: 30000000,
+      cacheTime: 30000000,
     });
   };
 

--- a/frontend/app/src/hooks/useComic.js
+++ b/frontend/app/src/hooks/useComic.js
@@ -79,7 +79,7 @@ export const useComic = () => {
       ),
       enabled: !!comicId,
       staleTime: 30000000,
-      cacheTime: 0,
+      cacheTime: 30000000,
     });
   };
 
@@ -111,8 +111,8 @@ export const useComic = () => {
     return useQuery({
       queryKey: 'scene_post_count',
       queryFn: () => comic.getScenePostCount(token),
-      staleTime: 300000,
-      cacheTime: 0,
+      staleTime: 30000000,
+      cacheTime: 30000000,
     });
   };
 

--- a/frontend/app/src/hooks/useScenePost.js
+++ b/frontend/app/src/hooks/useScenePost.js
@@ -19,7 +19,7 @@ export const useScenePost = () => {
           token || ''
         ),
       staleTime: 30000000,
-      cacheTime: 0,
+      cacheTime: 30000000,
     });
   };
 
@@ -40,16 +40,6 @@ export const useScenePost = () => {
         );
       },
       {
-        onSuccess: async (params) => {
-          const previousData = await queryClient.getQueryData(queryKey);
-
-          if (previousData) {
-            queryClient.setQueryData(queryKey, [
-              ...previousData,
-              params.data,
-            ])
-          }
-        },
         onError: (err, _, context) => {
           queryClient.setQueryData(queryKey, context);
 

--- a/frontend/app/src/hooks/useUser.js
+++ b/frontend/app/src/hooks/useUser.js
@@ -11,7 +11,7 @@ export const useUser = () => {
       queryKey: 'user',
       queryFn: () => user.getUser(token),
       staleTime: 30000000,
-      cacheTime: 0,
+      cacheTime: 30000000,
       retry: false,
     });
   };


### PR DESCRIPTION
【実装したこと】
「フロントエンド」
１　各投稿を表示する際に、react-queryのキャッシュ機能を使用していなかったので、可読性向上と表示パフォーマンス向上のためにキャッシュを使用するように変更しました。
【なぜこの変更をしたか？】
１　投稿を表示する際に、長いローディングで待たされるのは、ユーザビリティに欠けます。よりストレスなく、アプリを使用してもらうため。

以上が修正した点になります。気になる点があれば、修正いたします。