### PR TITLE
漫画新規投稿後の投稿完了画面追加とシーン新規投稿後の推移先変更

### DIFF
--- a/.github/workflows/mbg.yml
+++ b/.github/workflows/mbg.yml
@@ -3,7 +3,6 @@ name: Rails-Rspec-Rubocop-Deploy
 on:
   push:
     branches:
-      - develop
       - master
 
 jobs:

--- a/frontend/app/src/components/model/mypage/ComicNew.js
+++ b/frontend/app/src/components/model/mypage/ComicNew.js
@@ -25,8 +25,7 @@ const ComicNew = () => {
     } catch (error) {
       console.error(error.response.data);
     }
-    alert("新規登録が完了しました！");
-    navigate("/mypage");
+    navigate("/comic-completion");
   };
 
   return (

--- a/frontend/app/src/components/model/mypage/ui/ComicCompletion.js
+++ b/frontend/app/src/components/model/mypage/ui/ComicCompletion.js
@@ -1,0 +1,14 @@
+import { Link } from "react-router-dom";
+import complete from '../../../../css/model/mypage/ui/complete.module.css';
+import { FcOk } from "react-icons/fc";
+
+const ComicCompletion = () => {
+  return (
+    <div className={complete.wrapper}>
+      <div className={complete.title}><span className={complete["react-icon"]}><FcOk /></span>投稿が完了しました！</div>
+      <Link to='/mypage' className={complete.mypage}>マイページへ戻る</Link>
+    </div>
+  );
+};
+
+export default ComicCompletion;

--- a/frontend/app/src/components/model/scene_post/ScenePostNew.js
+++ b/frontend/app/src/components/model/scene_post/ScenePostNew.js
@@ -34,7 +34,7 @@ const ScenePostNew = () => {
       console.error(error.response.data);
     }
     alert("新規登録が完了しました！");
-    navigate("/mypage");
+    navigate(`/comic/${comic_id}/${comic_title}`);
   };
 
   //プルダウンリスト

--- a/frontend/app/src/css/model/mypage/ui/complete.module.css
+++ b/frontend/app/src/css/model/mypage/ui/complete.module.css
@@ -1,0 +1,54 @@
+.wrapper {
+  text-align: center;
+  margin-top: 180px;
+  font-size: 50px;
+  color: #32cd32 ;
+}
+
+.title {
+  margin-bottom: 50px;
+}
+
+.react-icon {
+  vertical-align: -6px;
+  margin-right: 8px;
+}
+
+.mypage {
+  border: 2px solid #a9a9a9;
+  border-radius: 5px;
+  box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+  font-size: 50px;
+  font-weight: 700;
+  padding: 14px 70px;
+  background-color: #a9a9a9;
+  color: white;
+}
+
+.mypage:hover {
+  opacity: 0.5;
+}
+
+@media screen and (min-width: 541px) and (max-width: 1024px) {
+  .wrapper {
+    font-size: 40px;
+  }
+}
+
+@media screen and (max-width: 540px) {
+  .wrapper {
+    margin-top: 80px;
+    font-size: 19px;
+  }
+
+  .mypage {
+    border: 2px solid #a9a9a9;
+    border-radius: 5px;
+    box-shadow: 2.7px 3.2px 2px 0.3px #938d90;
+    font-size: 20px;
+    font-weight: 700;
+    padding: 10px 20px;
+    background-color: #a9a9a9;
+    color: white;
+  }
+}

--- a/frontend/app/src/hooks/useComment.js
+++ b/frontend/app/src/hooks/useComment.js
@@ -39,16 +39,6 @@ export const useComment = () => {
         );
       },
       {
-        onSuccess: async (params) => {
-          const previousData = await queryClient.getQueryData(queryKey);
-
-          if (previousData) {
-            queryClient.setQueriesData(queryKey, [
-              ...previousData,
-              params.data,
-            ])
-          }
-        },
         onError: (err, _, context) => {
           queryClient.setQueryData(queryKey, context);
 

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -3,25 +3,33 @@ export { default as TermsOfService } from '../components/TermsOfService';
 export { default as PrivacyPolicy } from '../components/PrivacyPolicy';
 export { default as MyPage } from '../components/MyPage';
 export { default as ProfileEdit } from '../components/model/profile/ProfileEdit';
+//scenePost群
 export { default as ScenePost } from '../components/model/scene_post/ScenePost';
 export { default as ScenePostNew } from '../components/model/scene_post/ScenePostNew';
+export { default as ScenePostImageEdit } from '../components/model/scene_post/ui/ScenePostImageEdit';
 export { default as ScenePostShow } from '../components/model/scene_post/ScenePostShow';
 export { default as ScenePostEdit } from '../components/model/scene_post/ScenePostEdit';
-export { default as ComicEdit } from '../components/model/mypage/ComicEdit';
+export { default as ScenePostConfirmDelete } from '../components/model/scene_post/ui/ScenePostConfirmDelete';
 export { default as GeneralScenePost } from '../components/model/general/GeneralScenePost';
-export { default as GeneralComic } from '../components/model/general/GeneralComic';
 export { default as GeneralScenePostShow } from '../components/model/general/GeneralScenePostShow';
-export { default as Favorite } from '../components/model/mypage//favorite/Favorite';
+//comic群
+export { default as ComicEdit } from '../components/model/mypage/ComicEdit';
+export { default as ComicImageEdit } from '../components/model/mypage/ui/ComicImageEdit';
+export { default as ComicConfirmDelete } from '../components/model/mypage/ui/ComicConfirmDelete';
+export { default as ComicCompletion } from '../components/model/mypage/ui/ComicCompletion';
+export { default as GeneralComic } from '../components/model/general/GeneralComic';
 export { default as ComicNew } from '../components/model/mypage/ComicNew';
-export { default as Profile } from '../components/model/mypage/Profile';
 export { default as ComicPost } from '../components/model/mypage/ComicPost';
+//お気に入り群
+export { default as Favorite } from '../components/model/mypage//favorite/Favorite';
+//エラー群
 export { default as Page404 } from '../components/error/Page404';
+//プロフィール群
+export { default as Profile } from '../components/model/mypage/Profile';
 export { default as MyProfile } from '../components/model/profile/MyProfile';
+export { default as ProfileImageEdit } from '../components/model/profile/ui/ProfileImageEdit';
+//コメント群
 export { default as CommentNew } from '../components/model/comment/CommentNew';
+//ユーザー群
 export { default as GeneralUser } from '../components/model/user/GeneralUser';
 export { default as GeneralUserComic } from '../components/model/user/GeneralUserComic';
-export { default as ComicConfirmDelete } from '../components/model/mypage/ui/ComicConfirmDelete';
-export { default as ScenePostConfirmDelete } from '../components/model/scene_post/ui/ScenePostConfirmDelete';
-export { default as ComicImageEdit } from '../components/model/mypage/ui/ComicImageEdit';
-export { default as ScenePostImageEdit } from '../components/model/scene_post/ui/ScenePostImageEdit';
-export { default as ProfileImageEdit } from '../components/model/profile/ui/ProfileImageEdit';

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -23,6 +23,7 @@ import {
   GeneralUserComic,
   ComicConfirmDelete,
   ScenePostConfirmDelete,
+  ComicCompletion
 } from './Pages';
 
 const Routers = () => {
@@ -41,6 +42,7 @@ const Routers = () => {
       <Route path='/comic/:comic_id/:comic_title/comic_edit' element={ <ProtectedRoute component={ComicEdit}/> } />
       <Route path='/comic/:comic_id/:comic_title/comic_edit/comic-image-edit' element={ <ProtectedRoute component={ComicImageEdit}/> } />
       <Route path='/comic/:comic_id/:comic_title/comic_confirm_delete' element={ <ProtectedRoute component={ComicConfirmDelete}/> } />
+      <Route path='/comic-completion' element={ <ProtectedRoute component={ComicCompletion}/> } />
       <Route path='/general_scene_post/:comic_title/:comic_id' element={ <GeneralScenePost /> } />
       <Route path='/general_scene_post/:comic_title/general_scene_post_show/:scene_post_id' element={ <GeneralScenePostShow /> } />
       <Route path='/comic' element={ <GeneralComic /> } />


### PR DESCRIPTION
【実装したこと】
「フロントエンド」
１　漫画新規投稿後に投稿が完了した旨の画面を表示させるように変更しました。
２　シーンの新規投稿後の推移先をそのシーン一覧に変更しました。
３　GitHubActionsの発動条件をmasterブランチにコミットした場合のみに変更。
【変更をした理由】
１　ポップアップが表示されるよりも、より早い推移が可能であるreact-routerを使用する方がユーザビリティに優れていると思いました。
２　以前はマイページに戻るようになっていたので、投稿したシーンの内容がすぐに確認できる方がよりユーザビリティが上がると思いました。
３　masterブランチが本番環境用のブランチなので、developブランチでもデプロイしていると２重にデプロイすることになるので。

上記が変更した内容になります。気になる点があれば、再度調整いたします。