### PR TITLE
各ページのユーザーアイコンからユーザー詳細画面に飛べるように実装

### DIFF
--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -20,6 +20,7 @@ const Home = () => {
 
   if(comicLoading) return <></>
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
+  console.log(comics)
 
   return (
     <div className={home.wrapper}>
@@ -58,7 +59,12 @@ const Home = () => {
             <div key={comic.id} className={generalComic.content}>
               <div className={generalComic["innner-content"]}>
                 <div className={generalComic.list}>
-                  <div className={generalComic["user-name"]}><img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} /><UserInformationName userName={comic.attributes.comicUserName} />{ comic.attributes.comicUserName }</div>
+                  <div className={generalComic["user-name"]}>
+                    <Link to={`/users/${comic.attributes.userId}/comics`} >
+                      <img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />
+                    </Link>
+                    <UserInformationName userName={comic.attributes.comicUserName} />{ comic.attributes.comicUserName }
+                  </div>
                   <div className={generalComic["detail-area"]}>
                     <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcReading /></span>漫画名</p>
                     <div>{ comic.attributes.title }</div>

--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -21,7 +21,6 @@ const Home = () => {
 
   if(comicLoading) return <></>
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
-  console.log(comics)
 
   return (
     <div className={home.wrapper}>

--- a/frontend/app/src/components/Home.js
+++ b/frontend/app/src/components/Home.js
@@ -12,6 +12,7 @@ import { BsChevronDoubleDown } from "react-icons/bs";
 import { FcReading, FcFile, FcCalendar, FcMms, FcHome } from "react-icons/fc";
 import moment from 'moment';
 import { UserInformationName } from './ui/UserInformationDisplay';
+import ScenePostCount from './ui/ScenePostCount';
 
 const Home = () => {
   const { useGetGeneralLatestComic } = useGeneralComic();
@@ -81,6 +82,11 @@ const Home = () => {
                   <div className={generalComic["detail-area-image"]}>
                     <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["react-icon"]}><FcCalendar /></span>{ moment(comic.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
                     <img className={generalComic.image} src={ comic.attributes.image.url } alt='画像' onError={(e) => e.target.src = scenery} />
+                    <div className={generalComic['detail-area-count']}>
+                      <div className={generalComic['detail-area-list']}>
+                        <ScenePostCount comicId={comic.id} />
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/app/src/components/model/comment/Comment.js
+++ b/frontend/app/src/components/model/comment/Comment.js
@@ -8,6 +8,7 @@ import { useContext } from "react";
 import { useGeneralComment } from "../../../hooks/useGeneralComment";
 import moment from 'moment';
 import { FcCalendar } from "react-icons/fc";
+import { Link } from "react-router-dom";
 
 const Comment = ({scene_post_id}) => {
   const { useGetComment } = useComment();
@@ -30,7 +31,11 @@ const Comment = ({scene_post_id}) => {
           {comments.data?.map((comment) => (
             <div key={comment.id} className={commentCss["innner-content"]}>
               <div className={commentCss.list}>
-                <div className={commentCss["user-name"]}><img className={commentCss["user-image"]} src={ comment.attributes.comment_user_image.url } alt='画像' onError={(e) => e.target.src = noimage} />{ comment.attributes.comment_user_name }</div>
+                <div className={commentCss["user-name"]}>
+                <Link to={`/users/${comment.attributes.user_id}/comics`} >
+                  <img className={commentCss["user-image"]} src={ comment.attributes.comment_user_image.url } alt='画像' onError={(e) => e.target.src = noimage} />
+                </Link>
+                  { comment.attributes.comment_user_name }</div>
                 <div className={commentCss["detail-area"]}>
                   <div>{ comment.attributes.body }</div>
                 </div>

--- a/frontend/app/src/components/model/favoriteRanking/FavoriteRanking.js
+++ b/frontend/app/src/components/model/favoriteRanking/FavoriteRanking.js
@@ -41,6 +41,7 @@ const FavoriteRanking = () => {
           scenePostCreatedAt={scene_post.attributes.created_at}
           favorite={scene_post.attributes.favorite}
           comicTitle={scene_post.attributes.scene_post_comic_title}
+          userId={scene_post.attributes.user_id}
           />
         ))}
       </div>

--- a/frontend/app/src/components/model/favoriteRanking/ui/FavoriteRankingCard.js
+++ b/frontend/app/src/components/model/favoriteRanking/ui/FavoriteRankingCard.js
@@ -13,7 +13,6 @@ import moment from 'moment';
 import noimage from "../../../../image/default.png";
 import scenery from "../../../../image/scenery.png";
 
-
 const FavoriteRankingCard = ({
   index,
   scenePostId,

--- a/frontend/app/src/components/model/favoriteRanking/ui/FavoriteRankingCard.js
+++ b/frontend/app/src/components/model/favoriteRanking/ui/FavoriteRankingCard.js
@@ -24,7 +24,8 @@ const FavoriteRankingCard = ({
   scenePostNumber,
   scenePostImage,
   favorite,
-  comicTitle
+  comicTitle,
+  userId
 }) => {
   const [ favoriteState, setFavoriteState ] = useState(favorite);
   const { useGetGeneralComment } = useGeneralComment();
@@ -44,9 +45,11 @@ const FavoriteRankingCard = ({
       <div className={generalScenePost["innner-content"]}>
         <div className={generalScenePost.list}>
           <div className={generalScenePost["user-name"]}>
-            <img className={generalScenePost["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />
-            <UserInformationName userName={scenePostUserName} />
-            { scenePostUserName }
+            <Link to={`/users/${userId}/comics`} >
+              <img className={generalScenePost["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />
+              <UserInformationName userName={scenePostUserName} />
+              { scenePostUserName }
+            </Link>
           </div>
           <div className={generalScenePost["outer-favorite"]}>
             {favoriteState ? (

--- a/frontend/app/src/components/model/general/GeneralComic.js
+++ b/frontend/app/src/components/model/general/GeneralComic.js
@@ -7,14 +7,16 @@ import generalComic from "../../../css/model/general/generalComic.module.css";
 import subMenu from '../../../css/ui/subMenu.module.css';
 import { AiFillHome } from "react-icons/ai";
 import { FcReading, FcFile, FcCalendar, FcMms, FcSearch } from "react-icons/fc";
-import { useMemo, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import moment from 'moment';
 import { UserInformationName } from "../../ui/UserInformationDisplay";
 import ScenePostCount from "../../ui/ScenePostCount";
+import { AuthContext } from "../../../providers/AuthGuard";
 
 const GeneralComic = () => {
   const { useGetGeneralComic } = useGeneralComic();
   const { data: comics, isLoading } = useGetGeneralComic();
+  const { isAuthenticated } = useContext(AuthContext);
 
   let data = comics === undefined ? [{ length: 0 }] : comics.data;
 
@@ -111,9 +113,15 @@ const GeneralComic = () => {
                   <p className={generalComic.detail}><span className={generalComic["react-icon"]}><FcFile /></span>ジャンル</p>
                   <div>{ comic.attributes.genre }</div>
                 </div>
-                <div className={generalComic["detail-area-link"]}>
-                  <Link to={`/general_scene_post/${comic.attributes.title}/${comic.id}`} className={generalComic["link-show"]} ><span className={generalComic["react-icon"]}><FcMms /></span>シーンを見る</Link>
-                </div>
+                { isAuthenticated ?
+                  <div className={generalComic["detail-area-link"]}>
+                    <Link to={`/general_login_scene_post/${comic.attributes.title}/${comic.id}`} className={generalComic["link-show"]} ><span className={generalComic["react-icon"]}><FcMms /></span>シーンを見る</Link>
+                  </div>
+                :
+                  <div className={generalComic["detail-area-link"]}>
+                    <Link to={`/general_scene_post/${comic.attributes.title}/${comic.id}`} className={generalComic["link-show"]} ><span className={generalComic["react-icon"]}><FcMms /></span>シーンを見る</Link>
+                  </div>
+                }
               </div>
               <div className={generalComic["outer-image"]}>
                 <div className={generalComic["detail-area-image"]}>

--- a/frontend/app/src/components/model/general/GeneralComic.js
+++ b/frontend/app/src/components/model/general/GeneralComic.js
@@ -10,6 +10,7 @@ import { FcReading, FcFile, FcCalendar, FcMms, FcSearch } from "react-icons/fc";
 import { useMemo, useState } from "react";
 import moment from 'moment';
 import { UserInformationName } from "../../ui/UserInformationDisplay";
+import ScenePostCount from "../../ui/ScenePostCount";
 
 const GeneralComic = () => {
   const { useGetGeneralComic } = useGeneralComic();
@@ -71,7 +72,7 @@ const GeneralComic = () => {
           <span className={subMenu.home}>
             <Link to='/' className={subMenu["home-link"]}><span className={subMenu["react-icons"]}><AiFillHome /></span>ホーム</Link>
           </span>
-          <span>/ 漫画一覧</span>
+          <span>/&nbsp;漫画一覧</span>
         </div>
       </div>
       <div className={generalComic.count}>【投稿数】&nbsp;{comics.data.length}件</div>
@@ -96,7 +97,9 @@ const GeneralComic = () => {
             <div className={generalComic["innner-content"]}>
               <div className={generalComic.list}>
                 <div className={generalComic["user-name"]}>
-                  <img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />
+                  <Link to={`/users/${comic.attributes.userId}/comics`} >
+                    <img className={generalComic["user-image"]} src={ comic.attributes.comicUserImage.url } alt='画像' onError={(e) => e.target.src = noimage} />
+                  </Link>
                   <UserInformationName userName={comic.attributes.comicUserName} />
                   { comic.attributes.comicUserName }
                 </div>
@@ -116,6 +119,11 @@ const GeneralComic = () => {
                 <div className={generalComic["detail-area-image"]}>
                   <div className={generalComic["create-at"]}><span className={generalComic["detail-text"]}><span className={generalComic["react-icon"]}><FcCalendar /></span>{ moment(comic.attributes.createdAt).format('YYYY年MM月DD日HH:mm') }</span></div>
                   <img className={generalComic.image} src={ comic.attributes.image.url } alt='画像' onError={(e) => e.target.src = scenery} />
+                  <div className={generalComic['detail-area-count']}>
+                    <div className={generalComic['detail-area-list']}>
+                      <ScenePostCount comicId={comic.id} />
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/app/src/components/model/general/GeneralLoginScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralLoginScenePost.js
@@ -1,36 +1,34 @@
-import { useParams, Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
+import { AiFillHome } from "react-icons/ai";
 import { useGeneralScenePost } from "../../../hooks/useGeneralScenePost";
 import ReactLoading from "react-loading";
-import generalScenePost from '../../../css/model/general/generalScenePost.module.css';
-import subMenu from '../../../css/ui/subMenu.module.css';
-import { AiFillHome } from "react-icons/ai";
-import GeneralScenePostCard from "./ui/GeneralScenePostCard";
 import { useMemo, useState } from "react";
 import { FcSearch } from "react-icons/fc";
+import GeneralLoginScenePostCard from "./ui/GeneralLoginScenePostCard";
+import generalScenePost from '../../../css/model/general/generalScenePost.module.css';
+import subMenu from '../../../css/ui/subMenu.module.css';
 
-const GeneralScenePost = () => {
+const GeneralLoginScenePost = () => {
   const { comic_id, comic_title } = useParams();
-  const { useGetGeneralScenePost } = useGeneralScenePost();
+  const { useGetLoginGeneralScenePost } = useGeneralScenePost();
 
-  const { data: scene_posts, isLoading } = useGetGeneralScenePost(comic_id);
+  const { data: scene_posts, isLoading } = useGetLoginGeneralScenePost(comic_id);
 
   let data = scene_posts === undefined ? [{ length: 0 }] : scene_posts.data;
 
   const [searchText, setSearchText] = useState('');
 
-  // 検索用関数
   const searchKeywords = searchText.trim().match(/[^\s]+/g);
   if (searchKeywords !== null) {
     data = scene_posts.data.filter((scene_post) =>
       searchKeywords.every(
-        (kw) => scene_post.attributes.subTitle.indexOf(kw) !== -1
+        (kw) => scene_post.attributes.sub_title.indexOf(kw) !== -1
       )
     );
   };
 
   const [ sort, setSort ] = useState({});
 
-  // 並び替え用関数
   const sortedData = useMemo(() => {
     let _sortedData = data;
     if (sort.key) {
@@ -79,7 +77,7 @@ const GeneralScenePost = () => {
       </div>
       <div className={generalScenePost.count}>【投稿数】&nbsp;{scene_posts.data.length}件</div>
       <div className={generalScenePost.sort}>
-        <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え </button>
+        <button className={sort.key === 'id' ? sort.order === 1 ? 'button active asc' : 'button active desc' : 'button'} onClick={() => handleSort('id')}>並び替え</button>
       </div>
       <div className={generalScenePost.search}>
         <span className={generalScenePost["fc-search"]}><FcSearch /></span>
@@ -95,18 +93,19 @@ const GeneralScenePost = () => {
       ) }
       <div className={generalScenePost["main-content"]}>
         {sortedData.map((scene_post, index) => (
-          <GeneralScenePostCard
+          <GeneralLoginScenePostCard
             key={index}
             scenePostId={scene_post.id}
-            scenePostSubTitle={scene_post.attributes.subTitle}
-            scenePostUserImage={scene_post.attributes.scenePostUserImage.url}
-            scenePostUserName={scene_post.attributes.scenePostUserName}
-            scenePostNumber={scene_post.attributes.sceneNumber}
-            scenePostImage={scene_post.attributes.sceneImage.url}
-            scenePostCreatedAt={scene_post.attributes.createdAt}
+            scenePostSubTitle={scene_post.attributes.sub_title}
+            scenePostUserImage={scene_post.attributes.scene_post_user_image.url}
+            scenePostUserName={scene_post.attributes.scene_post_user_name}
+            scenePostNumber={scene_post.attributes.scene_number}
+            scenePostImage={scene_post.attributes.scene_image.url}
+            scenePostCreatedAt={scene_post.attributes.created_at}
             favorite={scene_post.attributes.favorite}
             comicTitle={comic_title}
-            userId={scene_post.attributes.userId}
+            comicId={scene_post.attributes.comicId}
+            userId={scene_post.attributes.user_id}
           />
         ))}
       </div>
@@ -114,4 +113,4 @@ const GeneralScenePost = () => {
   );
 };
 
-export default GeneralScenePost;
+export default GeneralLoginScenePost;

--- a/frontend/app/src/components/model/general/GeneralScenePost.js
+++ b/frontend/app/src/components/model/general/GeneralScenePost.js
@@ -110,6 +110,7 @@ const GeneralScenePost = () => {
 
   if(isLoading) return <ReactLoading type="spin" color='blue' className='loading' />
   if(general_loading) return <ReactLoading type="spin" color='blue' className='loading' />
+  console.log(sortedGeneralData)
 
   return (
     <div className={subMenu.wrapper}>
@@ -154,6 +155,7 @@ const GeneralScenePost = () => {
                 scenePostCreatedAt={scene_post.attributes.created_at}
                 favorite={scene_post.attributes.favorite}
                 comicTitle={comic_title}
+                comicId={scene_post.attributes.comicId}
               />
             ))}
           </div>
@@ -188,6 +190,7 @@ const GeneralScenePost = () => {
                 scenePostCreatedAt={scene_post.attributes.createdAt}
                 favorite={scene_post.attributes.favorite}
                 comicTitle={comic_title}
+                userId={scene_post.attributes.userId}
               />
             ))}
           </div>

--- a/frontend/app/src/components/model/general/ui/GeneralLoginScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralLoginScenePostCard.js
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useFavorite } from "../../../../hooks/useFavorite";
+import { useGeneralComment } from "../../../../hooks/useGeneralComment";
+import FavoriteButton from "../../../ui/FavoriteButton";
+import UnFavoriteButton from "../../../ui/UnFavoriteButton";
+import { UserInformationName } from "../../../ui/UserInformationDisplay";
+import { FcFilm, FcContacts, FcCalendar, FcMms, FcSms } from "react-icons/fc";
+import moment from 'moment';
+import noimage from "../../../../image/default.png";
+import scenery from "../../../../image/scenery.png";
+import generalScenePost from '../../../../css/model/general/generalScenePost.module.css';
+
+const GeneralLoginScenePostCard = ({
+  scenePostId,
+  scenePostSubTitle,
+  scenePostUserImage,
+  scenePostCreatedAt,
+  scenePostUserName,
+  scenePostNumber,
+  scenePostImage,
+  favorite,
+  comicTitle,
+  userId
+}) => {
+  const [ favoriteState, setFavoriteState ] = useState(favorite);
+
+  const { useGetGeneralComment } = useGeneralComment();
+  const { useGetFavorites_count } = useFavorite();
+
+  const { data: generalComments, isLoading } = useGetGeneralComment(scenePostId);
+  const { data: favorites, favoritesLoading } = useGetFavorites_count(scenePostId);
+
+  if(isLoading) return <></>
+  if(favoritesLoading) return <></>
+
+  return (
+    <div className={generalScenePost.content}>
+      <div className={generalScenePost["innner-content"]}>
+        <div className={generalScenePost.list}>
+          <div className={generalScenePost["user-name"]}>
+            <Link to={`/users/${userId}/comics`} >
+              <img className={generalScenePost["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />
+              <UserInformationName userName={scenePostUserName} />
+              { scenePostUserName }
+            </Link>
+          </div>
+          <div className={generalScenePost["outer-favorite"]}>
+            {favoriteState ? (
+              <UnFavoriteButton
+                id={scenePostId}
+                changeFavorite={setFavoriteState}
+              />
+            ) : (
+              <FavoriteButton
+                id={scenePostId}
+                changeFavorite={setFavoriteState}
+              />
+            )}
+            <div className={generalScenePost["favorite-count"]}>{ favorites?.length }</div>
+          </div>
+          <div className={generalScenePost["detail-area"]}>
+            <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcFilm /></span>サブタイトル</p>
+            <div>{ scenePostSubTitle }</div>
+          </div>
+          <div className={generalScenePost["detail-area"]}>
+            <p className={generalScenePost.detail}><span className={generalScenePost["react-icon"]}><FcContacts /></span>シーンの話数</p>
+            <div>{ scenePostNumber }話</div>
+          </div>
+          <div className={generalScenePost["detail-area-link"]}>
+            <Link to={`/general_scene_post/${comicTitle}/general_scene_post_show/${scenePostId}`} className={generalScenePost["link-show"]} ><span className={generalScenePost["react-icon"]}><FcMms /></span>シーンを見る</Link>
+          </div>
+        </div>
+        <div className={generalScenePost["outer-image"]}>
+          <div className={generalScenePost["detail-area-image"]}>
+            <div className={generalScenePost["create-at"]}><span className={generalScenePost["detail-text"]}><span className={generalScenePost["react-icon"]}><FcCalendar /></span>{ moment(scenePostCreatedAt).format('YYYY年MM月DD日HH:mm') }</span></div>
+            <img className={generalScenePost.image} src={ scenePostImage } alt='画像' onError={(e) => e.target.src = scenery} />
+            <div className={generalScenePost['detail-area-count']}>
+              <div className={generalScenePost['detail-area-list']}>
+                <div><span className={generalScenePost["react-icon"]}><FcSms /></span>コメント&nbsp;{ generalComments.data.length }件</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GeneralLoginScenePostCard;

--- a/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
+++ b/frontend/app/src/components/model/general/ui/GeneralScenePostCard.js
@@ -21,7 +21,8 @@ const GeneralScenePostCard = ({
   scenePostNumber,
   scenePostImage,
   favorite,
-  comicTitle
+  comicTitle,
+  userId
 }) => {
   const [ favoriteState, setFavoriteState ] = useState(favorite);
   const { isAuthenticated, loginWithRedirect } = useContext(AuthContext);
@@ -39,9 +40,11 @@ const GeneralScenePostCard = ({
       <div className={generalScenePost["innner-content"]}>
         <div className={generalScenePost.list}>
           <div className={generalScenePost["user-name"]}>
-            <img className={generalScenePost["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />
-            <UserInformationName userName={scenePostUserName} />
-            { scenePostUserName }
+            <Link to={`/users/${userId}/comics`} >
+              <img className={generalScenePost["user-image"]} src={ scenePostUserImage } alt='画像' onError={(e) => e.target.src = noimage} />
+              <UserInformationName userName={scenePostUserName} />
+              { scenePostUserName }
+            </Link>
           </div>
           <div className={generalScenePost["outer-favorite"]}>
             {isAuthenticated ? (

--- a/frontend/app/src/components/model/user/ui/GeneralUserCard.js
+++ b/frontend/app/src/components/model/user/ui/GeneralUserCard.js
@@ -26,7 +26,9 @@ const GeneralUserCard = ({
       <div className={generalUser["innner-content"]}>
         <div className={generalUser.list}>
           <div className={generalUser["user-name"]}>
-            <img className={generalUser["user-image"]} src={ userImage } alt='画像' onError={(e) => e.target.src = noimage} />
+            <Link to={`/users/${userId}/comics`} >
+              <img className={generalUser["user-image"]} src={ userImage } alt='画像' onError={(e) => e.target.src = noimage} />
+            </Link>
             <span className={generalUser["react-icon"]}><FcPodiumWithSpeaker /></span>ユーザー名&nbsp;<span className={generalUser["user-name-text"]}><UserInformationName userName={userName} />{ userName }</span>
           </div>
           <div className={generalUser['detail-area']}>

--- a/frontend/app/src/components/ui/ScenePostCount.js
+++ b/frontend/app/src/components/ui/ScenePostCount.js
@@ -1,0 +1,18 @@
+import { useGeneralScenePost } from "../../hooks/useGeneralScenePost";
+import generalScenePost from '../../css/model/general/generalScenePost.module.css';
+import { FcFilm } from "react-icons/fc";
+
+const ScenePostCount = ({comicId}) => {
+  const { useGetGeneralScenePost } = useGeneralScenePost();
+  const { data: scene_posts, isLoading } = useGetGeneralScenePost(comicId);
+
+  if(isLoading) return <></>
+
+  return (
+    <div>
+      <span className={generalScenePost["react-icon"]}><FcFilm /></span>シーン数&nbsp;{ scene_posts.data.length }件
+    </div>
+  );
+};
+
+export default ScenePostCount;

--- a/frontend/app/src/css/model/comment/comment.module.css
+++ b/frontend/app/src/css/model/comment/comment.module.css
@@ -28,6 +28,10 @@
   margin-right: 20px;
 }
 
+.user-image:hover {
+  opacity: 0.8;
+}
+
 .react-icon {
   font-size: 24px;
   vertical-align: -6px;

--- a/frontend/app/src/css/model/general/generalComic.module.css
+++ b/frontend/app/src/css/model/general/generalComic.module.css
@@ -77,6 +77,10 @@
   margin-right: 20px;
 }
 
+.user-image:hover {
+  opacity: 0.8;
+}
+
 .detail-area {
   margin-top: 20px;
   margin-bottom: 20px;

--- a/frontend/app/src/css/model/general/generalComic.module.css
+++ b/frontend/app/src/css/model/general/generalComic.module.css
@@ -132,6 +132,7 @@
 }
 
 .image {
+  padding-bottom: 20px;
   height: 250px;
   width: 100%;
   object-fit: contain;
@@ -140,6 +141,18 @@
 .list {
   padding: 15px;
   width: 100%;
+}
+
+.detail-area-count {
+  margin-top: -10px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.detail-area-list {
+  width: 100%;
+  margin-right: 10px;
+  text-align: center;
 }
 
 @media screen and (min-width: 541px) and (max-width: 1024px) {

--- a/frontend/app/src/css/model/general/generalScenePost.module.css
+++ b/frontend/app/src/css/model/general/generalScenePost.module.css
@@ -78,6 +78,10 @@
   margin-right: 20px;
 }
 
+.user-image:hover {
+  opacity: 0.8;
+}
+
 .detail-area {
   margin-top: 20px;
   margin-bottom: 20px;

--- a/frontend/app/src/css/model/user/generalUser.module.css
+++ b/frontend/app/src/css/model/user/generalUser.module.css
@@ -48,6 +48,10 @@
   margin-right: 20px;
 }
 
+.user-image:hover {
+  opacity: 0.8;
+}
+
 .detail-area {
   padding-bottom: 15px;
   margin-top: 20px;

--- a/frontend/app/src/route/Pages.js
+++ b/frontend/app/src/route/Pages.js
@@ -13,6 +13,7 @@ export { default as ScenePostShow } from '../components/model/scene_post/ScenePo
 export { default as ScenePostEdit } from '../components/model/scene_post/ScenePostEdit';
 export { default as ScenePostConfirmDelete } from '../components/model/scene_post/ui/ScenePostConfirmDelete';
 export { default as GeneralScenePost } from '../components/model/general/GeneralScenePost';
+export { default as GeneralLoginScenePost } from '../components/model/general/GeneralLoginScenePost';
 export { default as GeneralScenePostShow } from '../components/model/general/GeneralScenePostShow';
 //comic群
 export { default as ComicEdit } from '../components/model/mypage/ComicEdit';

--- a/frontend/app/src/route/Routers.js
+++ b/frontend/app/src/route/Routers.js
@@ -13,6 +13,7 @@ import {
   ScenePostEdit,
   ScenePostImageEdit,
   GeneralScenePost,
+  GeneralLoginScenePost,
   GeneralComic,
   GeneralScenePostShow,
   Page404,
@@ -46,6 +47,7 @@ const Routers = () => {
       <Route path='/comic/:comic_id/:comic_title/comic_confirm_delete' element={ <ProtectedRoute component={ComicConfirmDelete}/> } />
       <Route path='/comic-completion' element={ <ProtectedRoute component={ComicCompletion}/> } />
       <Route path='/general_scene_post/:comic_title/:comic_id' element={ <GeneralScenePost /> } />
+      <Route path='/general_login_scene_post/:comic_title/:comic_id' element={ <ProtectedRoute component={GeneralLoginScenePost}/> } />
       <Route path='/general_favorites_ranking' element={ <GeneralFavoritesRanking /> } />
       <Route path='/favorite_ranking' element={ <ProtectedRoute component={FavoriteRanking}/> } />
       <Route path='/general_scene_post/:comic_title/general_scene_post_show/:scene_post_id' element={ <GeneralScenePostShow /> } />


### PR DESCRIPTION
【実装したこと】
「フロントエンド」
１　各ページのユーザーアイコンにユーザー詳細画面までへのリンクを追加
【なぜこの変更をしたか】
１　ユーザビリティ向上のため

実装した点は上記になります。気になる点があれば再度修正いたします。